### PR TITLE
Chore: test exec speedup

### DIFF
--- a/.github/actions/e2e-boot/action.yml
+++ b/.github/actions/e2e-boot/action.yml
@@ -41,3 +41,27 @@ runs:
         echo "$K3S_INSTALL_SHA256  /tmp/k3s-install.sh" | sha256sum -c -
         chmod +x /tmp/k3s-install.sh
         INSTALL_K3S_VERSION="$K3S_VERSION" INSTALL_K3S_EXEC="--disable=traefik --bind-address 0.0.0.0 --tls-san host.docker.internal" /tmp/k3s-install.sh
+
+    - name: Pre-pull executor images and Kueue manifest (background)
+      shell: bash
+      run: |
+        KUEUE_VERSION="${KUEUE_VERSION:-v0.16.1}"
+
+        nohup bash -c '
+          curl -fsSL -o /tmp/kueue-manifests.yaml \
+            "https://github.com/kubernetes-sigs/kueue/releases/download/'"$KUEUE_VERSION"'/manifests.yaml"
+          echo $? > /tmp/kueue-download.exit
+        ' > /tmp/kueue-download.log 2>&1 &
+        echo $! > /tmp/kueue-download.pid
+
+        nohup bash -c '
+          sudo k3s crictl pull docker.io/library/python:3.11-slim
+          echo $? > /tmp/crictl-python.exit
+        ' > /tmp/crictl-python.log 2>&1 &
+        echo $! > /tmp/crictl-python.pid
+
+        nohup bash -c '
+          sudo k3s crictl pull docker.io/library/busybox:1.36
+          echo $? > /tmp/crictl-busybox.exit
+        ' > /tmp/crictl-busybox.log 2>&1 &
+        echo $! > /tmp/crictl-busybox.pid

--- a/.github/actions/e2e-ready/action.yml
+++ b/.github/actions/e2e-ready/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Also wait for frontend health check (default: false)'
     required: false
     default: 'false'
+  install-kueue:
+    description: 'Install Kueue CRDs for executor pods (default: true)'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -26,18 +30,26 @@ runs:
           /home/runner/.kube/config > backend/kubeconfig.yaml
         chmod 644 backend/kubeconfig.yaml
 
-    - name: Install Kueue
+    - name: Install Kueue and wait for executor image pulls
+      if: inputs.install-kueue == 'true'
       shell: bash
       run: |
+        set -e
+
         KUEUE_VERSION="${KUEUE_VERSION:-v0.16.1}"
         KUEUE_MANIFEST_SHA256="${KUEUE_MANIFEST_SHA256:-3201a66ff731be440ecfcf3c0fa5979d001b834f68389208fe7ee18017fbcfe8}"
         KUEUE_MANIFEST="/tmp/kueue-manifests.yaml"
-        curl -fsSL -o "$KUEUE_MANIFEST" "https://github.com/kubernetes-sigs/kueue/releases/download/${KUEUE_VERSION}/manifests.yaml"
+
+        tail --pid="$(cat /tmp/kueue-download.pid)" -f /dev/null 2>/dev/null || true
+        cat /tmp/kueue-download.log 2>/dev/null || true
+        [ "$(cat /tmp/kueue-download.exit)" = "0" ]
+
         echo "${KUEUE_MANIFEST_SHA256}  ${KUEUE_MANIFEST}" | sha256sum -c -
         kubectl apply --server-side -f "$KUEUE_MANIFEST"
         rm -f "$KUEUE_MANIFEST"
         kubectl wait --for=condition=Available --timeout=120s \
           deployment/kueue-controller-manager -n kueue-system
+
         kubectl apply --server-side -f - <<'EOF'
         apiVersion: kueue.x-k8s.io/v1beta1
         kind: ResourceFlavor
@@ -69,34 +81,23 @@ runs:
           clusterQueue: executor-queue
         EOF
 
-    - name: Use test environment config
-      shell: bash
-      run: cp backend/config.test.toml backend/config.toml
+        tail --pid="$(cat /tmp/crictl-python.pid)" -f /dev/null 2>/dev/null || true
+        cat /tmp/crictl-python.log 2>/dev/null || true
+        [ "$(cat /tmp/crictl-python.exit)" = "0" ]
 
-    - name: Pre-pull test runtime images into K3s
+        tail --pid="$(cat /tmp/crictl-busybox.pid)" -f /dev/null 2>/dev/null || true
+        cat /tmp/crictl-busybox.log 2>/dev/null || true
+        [ "$(cat /tmp/crictl-busybox.exit)" = "0" ]
+
+    - name: Prepare config, wait for infra
       shell: bash
       run: |
-        sudo k3s crictl pull docker.io/library/python:3.11-slim
-        sudo k3s crictl pull docker.io/library/busybox:1.36
+        set -e
+        cp backend/config.test.toml backend/config.toml
 
-    - name: Wait for image pull and infra
-      shell: bash
-      run: |
-        if [ -f /tmp/infra-pull.pid ]; then
-          PID=$(cat /tmp/infra-pull.pid)
-          if kill -0 "$PID" 2>/dev/null; then
-            echo "Waiting for image pull + infra startup..."
-            tail --pid="$PID" -f /dev/null 2>/dev/null || true
-          fi
-        fi
+        tail --pid="$(cat /tmp/infra-pull.pid)" -f /dev/null 2>/dev/null || true
         cat /tmp/infra-pull.log 2>/dev/null || true
-        if [ -f /tmp/infra-pull.exit ]; then
-          EXIT_CODE=$(cat /tmp/infra-pull.exit)
-          if [ "$EXIT_CODE" != "0" ]; then
-            echo "::error::Background image pull / infra pre-warm failed (exit $EXIT_CODE)"
-            exit 1
-          fi
-        fi
+        [ "$(cat /tmp/infra-pull.exit)" = "0" ]
 
     - name: Start stack
       shell: bash
@@ -110,11 +111,10 @@ runs:
         WAIT_FOR_FRONTEND: ${{ inputs.wait-for-frontend }}
       run: |
         echo "Waiting for backend health..."
-        timeout 120 bash -c 'until curl -ksf https://localhost/api/v1/health/live 2>/dev/null; do sleep 2; done'
+        timeout 120 bash -c 'until curl -ksf https://localhost/api/v1/health/live 2>/dev/null; do sleep 1; done'
         echo "Backend ready"
         if [ "$WAIT_FOR_FRONTEND" = "true" ]; then
           echo "Waiting for frontend health..."
-          timeout 60 bash -c 'until curl -ksf https://localhost:5001 2>/dev/null; do sleep 2; done'
+          timeout 60 bash -c 'until curl -ksf https://localhost:5001 2>/dev/null; do sleep 1; done'
           echo "Frontend ready"
         fi
-

--- a/.github/actions/e2e-ready/action.yml
+++ b/.github/actions/e2e-ready/action.yml
@@ -40,7 +40,7 @@ runs:
         KUEUE_MANIFEST_SHA256="${KUEUE_MANIFEST_SHA256:-3201a66ff731be440ecfcf3c0fa5979d001b834f68389208fe7ee18017fbcfe8}"
         KUEUE_MANIFEST="/tmp/kueue-manifests.yaml"
 
-        tail --pid="$(cat /tmp/kueue-download.pid)" -f /dev/null 2>/dev/null || true
+        timeout 120 tail --pid="$(cat /tmp/kueue-download.pid)" -f /dev/null 2>/dev/null || true
         cat /tmp/kueue-download.log 2>/dev/null || true
         [ "$(cat /tmp/kueue-download.exit)" = "0" ]
 
@@ -81,11 +81,11 @@ runs:
           clusterQueue: executor-queue
         EOF
 
-        tail --pid="$(cat /tmp/crictl-python.pid)" -f /dev/null 2>/dev/null || true
+        timeout 120 tail --pid="$(cat /tmp/crictl-python.pid)" -f /dev/null 2>/dev/null || true
         cat /tmp/crictl-python.log 2>/dev/null || true
         [ "$(cat /tmp/crictl-python.exit)" = "0" ]
 
-        tail --pid="$(cat /tmp/crictl-busybox.pid)" -f /dev/null 2>/dev/null || true
+        timeout 120 tail --pid="$(cat /tmp/crictl-busybox.pid)" -f /dev/null 2>/dev/null || true
         cat /tmp/crictl-busybox.log 2>/dev/null || true
         [ "$(cat /tmp/crictl-busybox.exit)" = "0" ]
 
@@ -95,7 +95,7 @@ runs:
         set -e
         cp backend/config.test.toml backend/config.toml
 
-        tail --pid="$(cat /tmp/infra-pull.pid)" -f /dev/null 2>/dev/null || true
+        timeout 120 tail --pid="$(cat /tmp/infra-pull.pid)" -f /dev/null 2>/dev/null || true
         cat /tmp/infra-pull.log 2>/dev/null || true
         [ "$(cat /tmp/infra-pull.exit)" = "0" ]
 

--- a/.github/workflows/grimp.yml
+++ b/.github/workflows/grimp.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Run grimp orphan module check
         run: |
           cd backend
-          uv run python scripts/check_orphan_modules.py
+          uv run --no-sync python scripts/check_orphan_modules.py

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           cd backend
           uv python install 3.12
-          uv sync --frozen --group lint --no-dev
+          uv sync --frozen --group lint --group test --no-dev
 
       - name: Run mypy
         env:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -31,4 +31,4 @@ jobs:
           SECRET_KEY: ${{ secrets.TEST_SECRET_KEY }}
         run: |
           cd backend
-          uv run mypy --config-file pyproject.toml --strict .
+          uv run --no-sync mypy --config-file pyproject.toml --strict .

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Run ruff
         run: |
           cd backend
-          uv run ruff check . --config pyproject.toml
+          uv run --no-sync ruff check . --config pyproject.toml

--- a/.github/workflows/stack-tests.yml
+++ b/.github/workflows/stack-tests.yml
@@ -236,12 +236,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/actions/e2e-boot
+      - name: Boot E2E environment
+        uses: ./.github/actions/e2e-boot
         with:
           image-tag: ${{ needs.build-images.outputs.sha-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: ./.github/actions/e2e-ready
+      - name: Finalize k3s & start stack
+        uses: ./.github/actions/e2e-ready
         with:
           image-tag: ${{ needs.build-images.outputs.sha-tag }}
 
@@ -305,7 +307,8 @@ jobs:
       - uses: actions/checkout@v6
 
       # Phase 1: kick off image pull + infra + k3s in background
-      - uses: ./.github/actions/e2e-boot
+      - name: Boot E2E environment
+        uses: ./.github/actions/e2e-boot
         with:
           image-tag: ${{ needs.build-images.outputs.sha-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -339,10 +342,12 @@ jobs:
         run: npx playwright install chromium
 
       # Phase 3: finalize k3s + start stack (k3s has been booting since e2e-boot)
-      - uses: ./.github/actions/e2e-ready
+      - name: Finalize k3s & start stack
+        uses: ./.github/actions/e2e-ready
         with:
           image-tag: ${{ needs.build-images.outputs.sha-tag }}
           wait-for-frontend: 'true'
+          install-kueue: 'false'
 
       - name: Run Playwright tests
         timeout-minutes: 10

--- a/.github/workflows/stack-tests.yml
+++ b/.github/workflows/stack-tests.yml
@@ -58,7 +58,7 @@ jobs:
         timeout-minutes: 5
         run: |
           cd backend
-          uv run pytest tests/unit -v -rs \
+          uv run --no-sync pytest tests/unit -v -rs \
             --durations=0 \
             --cov=app \
             --cov-report=xml --cov-report=term

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -59,6 +59,7 @@
         "eslint-plugin-svelte": "^3.15.0",
         "express": "^5.2.1",
         "globals": "^17.3.0",
+        "happy-dom": "^20.8.3",
         "http-proxy": "^1.18.1",
         "jsdom": "^28.1.0",
         "monocart-reporter": "^2.10.0",
@@ -2550,8 +2551,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
       "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2571,17 +2570,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
       "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5299,12 +5294,10 @@
       "dev": true
     },
     "node_modules/happy-dom": {
-      "version": "20.7.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.7.0.tgz",
-      "integrity": "sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==",
+      "version": "20.8.3",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.3.tgz",
+      "integrity": "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -5322,8 +5315,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -5336,8 +5327,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5347,8 +5336,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -9773,9 +9760,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/unicorn-magic": {
       "version": "0.4.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,7 +61,6 @@
         "globals": "^17.3.0",
         "happy-dom": "^20.8.3",
         "http-proxy": "^1.18.1",
-        "jsdom": "^28.1.0",
         "monocart-reporter": "^2.10.0",
         "postcss": "^8.4.47",
         "postcss-lightningcss": "^1.0.2",
@@ -89,7 +88,9 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -114,6 +115,8 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
       "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.0.0",
         "@csstools/css-color-parser": "^4.0.1",
@@ -127,6 +130,8 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
@@ -139,7 +144,9 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -224,6 +231,8 @@
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "css-tree": "^3.0.0"
       },
@@ -433,6 +442,8 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -475,6 +486,8 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@csstools/color-helpers": "^6.0.1",
         "@csstools/css-calc": "^3.0.0"
@@ -1131,6 +1144,8 @@
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
       "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
@@ -3099,6 +3114,8 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -3272,6 +3289,8 @@
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
@@ -4015,6 +4034,8 @@
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
       "integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.2",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
@@ -4030,6 +4051,8 @@
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
         "whatwg-url": "^16.0.0"
@@ -4068,7 +4091,9 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/deep-equal": {
       "version": "1.0.1",
@@ -5408,6 +5433,8 @@
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
       },
@@ -5519,6 +5546,8 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -5532,6 +5561,8 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -5829,7 +5860,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
@@ -5935,6 +5968,8 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -6513,6 +6548,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -7125,6 +7162,8 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -7137,6 +7176,8 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -8525,6 +8566,8 @@
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -9477,7 +9520,9 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/table": {
       "version": "6.9.0",
@@ -9614,6 +9659,8 @@
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
       "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tldts-core": "^7.0.19"
       },
@@ -9625,7 +9672,9 @@
       "version": "7.0.19",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
       "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -9662,6 +9711,8 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
       "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tldts": "^7.0.5"
       },
@@ -9674,6 +9725,8 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -9752,6 +9805,8 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
       "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -10012,6 +10067,8 @@
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -10024,6 +10081,8 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -10033,6 +10092,8 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -10042,6 +10103,8 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
       "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
@@ -10151,6 +10214,8 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10159,7 +10224,9 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,6 @@
     "globals": "^17.3.0",
     "happy-dom": "^20.8.3",
     "http-proxy": "^1.18.1",
-    "jsdom": "^28.1.0",
     "monocart-reporter": "^2.10.0",
     "postcss": "^8.4.47",
     "postcss-lightningcss": "^1.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-svelte": "^3.15.0",
     "express": "^5.2.1",
     "globals": "^17.3.0",
+    "happy-dom": "^20.8.3",
     "http-proxy": "^1.18.1",
     "jsdom": "^28.1.0",
     "monocart-reporter": "^2.10.0",

--- a/frontend/src/__tests__/test-utils.ts
+++ b/frontend/src/__tests__/test-utils.ts
@@ -352,3 +352,19 @@ export const createMockUsers = (count: number): UserResponse[] =>
             is_active: i % 3 !== 0,
         }),
     );
+
+/**
+ * Selects an option in a <select> element by value.
+ *
+ * Works with Svelte's bind:value in both jsdom and happy-dom.
+ * Svelte reads the :checked option on change — not select.value —
+ * so we must mark the <option> as selected before dispatching.
+ */
+export function selectOption(element: HTMLElement, value: string): void {
+    const option = Array.from(element.querySelectorAll('option')).find((o) => o.value === value);
+    if (!option) {
+        throw new Error(`No <option value="${value}"> found`);
+    }
+    option.selected = true;
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+}

--- a/frontend/src/__tests__/test-utils.ts
+++ b/frontend/src/__tests__/test-utils.ts
@@ -26,6 +26,26 @@ import type {
 
 export type UserEventInstance = ReturnType<typeof userEvent.setup>;
 
+const _r = new Request('http://test');
+const _s = new Response();
+
+/**
+ * Fluent mock wrapper for hey-api SDK functions.
+ * Hides the `request`/`response` fields that `RequestResult` requires.
+ */
+export function mockApi(fn: (...args: any[]) => any) {
+    const mock = vi.mocked(fn) as ReturnType<typeof vi.fn>;
+    return {
+        ok(data: unknown) {
+            mock.mockResolvedValue({ data, error: undefined, request: _r, response: _s });
+        },
+        err(error: unknown) {
+            mock.mockResolvedValue({ data: undefined, error, request: _r, response: _s });
+        },
+        mock,
+    };
+}
+
 export const user: UserEventInstance = userEvent.setup({
     delay: null,
     pointerEventsCheck: 0,

--- a/frontend/src/components/Pagination.svelte
+++ b/frontend/src/components/Pagination.svelte
@@ -7,7 +7,7 @@
         totalItems: number;
         pageSize: number;
         onPageChange: (page: number) => void;
-        onPageSizeChange?: (size: number) => void;
+        onPageSizeChange?: () => void;
         pageSizeOptions?: number[];
         itemName?: string;
     }
@@ -16,7 +16,7 @@
         currentPage,
         totalPages,
         totalItems,
-        pageSize,
+        pageSize = $bindable(),
         onPageChange,
         onPageSizeChange,
         pageSizeOptions = [10, 25, 50, 100],
@@ -38,8 +38,8 @@
             {#if onPageSizeChange}
                 <select
                     class="pagination-selector"
-                    value={pageSize}
-                    onchange={(e) => onPageSizeChange?.(Number(e.currentTarget.value))}
+                    bind:value={pageSize}
+                    onchange={() => onPageSizeChange?.()}
                     aria-label="Items per page"
                 >
                     {#each pageSizeOptions as size}

--- a/frontend/src/components/__tests__/ErrorDisplay.test.ts
+++ b/frontend/src/components/__tests__/ErrorDisplay.test.ts
@@ -7,7 +7,6 @@ describe('ErrorDisplay', () => {
     let originalLocation: Location;
 
     beforeEach(() => {
-        // Mock window.location
         originalLocation = window.location;
         Object.defineProperty(window, 'location', {
             value: {

--- a/frontend/src/components/__tests__/Footer.test.ts
+++ b/frontend/src/components/__tests__/Footer.test.ts
@@ -6,7 +6,6 @@ describe('Footer', () => {
     let originalDate: DateConstructor;
 
     beforeEach(() => {
-        // Mock Date to have consistent year in tests
         originalDate = globalThis.Date;
         const mockDate = class extends Date {
             constructor() {
@@ -110,7 +109,6 @@ describe('Footer', () => {
         it('has screen reader text for social icons', () => {
             render(Footer);
 
-            // Check for sr-only spans
             expect(screen.getByText('Telegram', { selector: '.sr-only' })).toBeInTheDocument();
             expect(screen.getByText('GitHub', { selector: '.sr-only' })).toBeInTheDocument();
         });

--- a/frontend/src/components/__tests__/Header.test.ts
+++ b/frontend/src/components/__tests__/Header.test.ts
@@ -49,7 +49,6 @@ vi.mock('$components/NotificationCenter.svelte', () => {
 
 import Header from '$components/Header.svelte';
 
-// Test helpers
 const setAuth = (
     isAuth: boolean,
     username: string | null = null,
@@ -270,7 +269,6 @@ describe('Header', () => {
                 expect(screen.getByRole('link', { name: /Settings/i })).toBeInTheDocument();
             });
 
-            // Click outside the dropdown
             document.body.click();
 
             await waitFor(() => {
@@ -281,7 +279,6 @@ describe('Header', () => {
 
     describe('resize behavior', () => {
         it('closes mobile menu when resizing to desktop width', async () => {
-            // Start in mobile mode
             Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 800 });
 
             await openMobileMenu();
@@ -289,7 +286,6 @@ describe('Header', () => {
                 expect(screen.getByTestId('mobile-menu')).toBeInTheDocument();
             });
 
-            // Resize to desktop width
             Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1200 });
             window.dispatchEvent(new Event('resize'));
 
@@ -302,7 +298,6 @@ describe('Header', () => {
             Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 500 });
             render(Header);
 
-            // Mobile menu toggle should be visible
             expect(screen.getByTestId('mobile-menu-toggle')).toBeInTheDocument();
         });
     });

--- a/frontend/src/components/__tests__/Header.test.ts
+++ b/frontend/src/components/__tests__/Header.test.ts
@@ -22,12 +22,12 @@ const mocks = vi.hoisted(() => ({
     mockToggleTheme: vi.fn(),
 }));
 
-vi.mock('../../stores/auth.svelte', () => ({
+vi.mock('$stores/auth.svelte', () => ({
     get authStore() {
         return mocks.mockAuthStore;
     },
 }));
-vi.mock('../../stores/theme.svelte', () => ({
+vi.mock('$stores/theme.svelte', () => ({
     get themeStore() {
         return mocks.mockThemeStore;
     },
@@ -35,7 +35,7 @@ vi.mock('../../stores/theme.svelte', () => ({
         return mocks.mockToggleTheme;
     },
 }));
-vi.mock('../NotificationCenter.svelte', () => {
+vi.mock('$components/NotificationCenter.svelte', () => {
     const M = function () {
         return {};
     } as any;

--- a/frontend/src/components/__tests__/NotificationCenter.test.ts
+++ b/frontend/src/components/__tests__/NotificationCenter.test.ts
@@ -40,18 +40,18 @@ const mocks = vi.hoisted(() => ({
     mockStreamDisconnect: vi.fn(),
 }));
 
-vi.mock('@mateothegreat/svelte5-router', () => ({ goto: mocks.mockGoto }));
-vi.mock('../../stores/auth.svelte', () => ({
+vi.mock('@mateothegreat/svelte5-router', () => ({ route: () => {}, goto: mocks.mockGoto }));
+vi.mock('$stores/auth.svelte', () => ({
     get authStore() {
         return mocks.mockAuthStore;
     },
 }));
-vi.mock('../../stores/notificationStore.svelte', () => ({
+vi.mock('$stores/notificationStore.svelte', () => ({
     get notificationStore() {
         return mocks.mockNotificationStore;
     },
 }));
-vi.mock('../../lib/notifications/stream.svelte', () => ({
+vi.mock('$lib/notifications/stream.svelte', () => ({
     notificationStream: {
         connect: mocks.mockStreamConnect,
         disconnect: mocks.mockStreamDisconnect,

--- a/frontend/src/components/__tests__/NotificationCenter.test.ts
+++ b/frontend/src/components/__tests__/NotificationCenter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { user, type UserEventInstance } from '$test/test-utils';
-// Types for mock notification state
+
 interface MockNotification {
     notification_id: string;
     subject: string;
@@ -58,7 +58,6 @@ vi.mock('$lib/notifications/stream.svelte', () => ({
     },
 }));
 
-// Configurable Notification mock
 const mockRequestPermission = vi.fn().mockResolvedValue('granted');
 let mockNotificationPermission = 'default';
 vi.stubGlobal('Notification', {
@@ -70,7 +69,6 @@ vi.stubGlobal('Notification', {
 
 import NotificationCenter from '$components/NotificationCenter.svelte';
 
-// Test Helpers
 const createNotification = (overrides: Partial<MockNotification> = {}): MockNotification => ({
     notification_id: '1',
     subject: 'Test',
@@ -115,7 +113,6 @@ const interactWithButton = async (user: UserEventInstance, button: HTMLElement, 
     }
 };
 
-// Test Data (consolidated arrays for it.each)
 const iconTestCases = [
     { tags: ['completed'], iconClass: 'lucide-circle-check', desc: 'check' },
     { tags: ['success'], iconClass: 'lucide-circle-check', desc: 'check' },
@@ -154,7 +151,6 @@ const interactionTestCases = [
     { method: 'keyboard' as const, hasUrl: false, url: undefined },
 ];
 
-// Tests
 describe('NotificationCenter', () => {
     const openDropdown = async () => {
         render(NotificationCenter);

--- a/frontend/src/components/__tests__/Pagination.test.ts
+++ b/frontend/src/components/__tests__/Pagination.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
-import { user } from '$test/test-utils';
+import { user, selectOption } from '$test/test-utils';
 import Pagination from '$components/Pagination.svelte';
 
 const defaultProps = {
@@ -85,8 +85,8 @@ describe('Pagination', () => {
         it('fires onPageSizeChange on select change', async () => {
             const onPageSizeChange = vi.fn();
             renderPagination({ onPageSizeChange } as Record<string, unknown>);
-            await user.selectOptions(screen.getByRole('combobox'), '25');
-            expect(onPageSizeChange).toHaveBeenCalledWith(25);
+            selectOption(screen.getByRole('combobox'), '25');
+            expect(onPageSizeChange).toHaveBeenCalled();
         });
     });
 

--- a/frontend/src/components/__tests__/Spinner.test.ts
+++ b/frontend/src/components/__tests__/Spinner.test.ts
@@ -79,7 +79,6 @@ describe('Spinner', () => {
             // @ts-expect-error - intentionally passing invalid value to test fallback
             render(Spinner, { props: { size: 'invalid-size' } });
             const svg = getSpinner();
-            // Should fall back to medium (h-6 w-6)
             expect(svg.classList.contains('h-6')).toBe(true);
             expect(svg.classList.contains('w-6')).toBe(true);
         });
@@ -88,7 +87,6 @@ describe('Spinner', () => {
             // @ts-expect-error - intentionally passing invalid value to test fallback
             render(Spinner, { props: { color: 'invalid-color' } });
             const svg = getSpinner();
-            // Should fall back to primary
             expect(svg.classList.contains('text-primary')).toBe(true);
         });
 
@@ -96,7 +94,6 @@ describe('Spinner', () => {
             // @ts-expect-error - intentionally passing invalid values to test fallback
             render(Spinner, { props: { size: 'unknown', color: 'unknown' } });
             const svg = getSpinner();
-            // Should fall back to defaults
             expect(svg.classList.contains('h-6')).toBe(true);
             expect(svg.classList.contains('w-6')).toBe(true);
             expect(svg.classList.contains('text-primary')).toBe(true);

--- a/frontend/src/components/admin/AutoRefreshControl.svelte
+++ b/frontend/src/components/admin/AutoRefreshControl.svelte
@@ -31,18 +31,6 @@
         onEnabledChange,
         onRateChange,
     }: Props = $props();
-
-    function handleEnabledChange(e: Event): void {
-        const target = e.target as HTMLInputElement;
-        enabled = target.checked;
-        onEnabledChange?.(enabled);
-    }
-
-    function handleRateChange(e: Event): void {
-        const target = e.target as HTMLSelectElement;
-        rate = parseInt(target.value, 10);
-        onRateChange?.(rate);
-    }
 </script>
 
 <div class="card">
@@ -50,8 +38,8 @@
         <label class="flex items-center gap-2 cursor-pointer">
             <input
                 type="checkbox"
-                checked={enabled}
-                onchange={handleEnabledChange}
+                bind:checked={enabled}
+                onchange={() => onEnabledChange?.(enabled)}
                 class="w-4 h-4 rounded border-border-default text-primary focus:ring-primary"
             />
             <span class="text-sm font-medium text-fg-default dark:text-dark-fg-default">Auto-refresh</span>
@@ -60,7 +48,12 @@
         {#if enabled}
             <div class="flex items-center gap-2 flex-1 sm:flex-initial">
                 <label for="refresh-rate" class="text-xs sm:text-sm text-fg-muted">Every:</label>
-                <select id="refresh-rate" value={rate} onchange={handleRateChange} class="form-select-standard">
+                <select
+                    id="refresh-rate"
+                    bind:value={rate}
+                    onchange={() => onRateChange?.(rate)}
+                    class="form-select-standard"
+                >
                     {#each rateOptions as option}
                         <option value={option.value}>{option.label}</option>
                     {/each}

--- a/frontend/src/components/admin/users/__tests__/RateLimitsModal.test.ts
+++ b/frontend/src/components/admin/users/__tests__/RateLimitsModal.test.ts
@@ -79,7 +79,6 @@ describe('RateLimitsModal', () => {
 
     it('shows spinner when loading', () => {
         renderModal({ loading: true, config: null });
-        // When config is null, spinner is shown
         expect(screen.queryByText('Quick Settings')).not.toBeInTheDocument();
     });
 

--- a/frontend/src/components/admin/users/__tests__/RateLimitsModal.test.ts
+++ b/frontend/src/components/admin/users/__tests__/RateLimitsModal.test.ts
@@ -9,20 +9,7 @@ vi.mock('$components/Spinner.svelte', async () => {
     return { default: utils.createMockNamedComponents({ default: '<span data-testid="spinner">...</span>' }).default };
 });
 
-vi.mock('$lib/api', () => ({
-    getDefaultRateLimitRulesApiV1AdminRateLimitsDefaultsGet: vi.fn().mockResolvedValue({
-        data: [
-            {
-                endpoint_pattern: '/api/v1/*',
-                requests: 100,
-                window_seconds: 60,
-                group: 'general',
-                algorithm: 'sliding_window',
-                enabled: true,
-            },
-        ],
-    }),
-}));
+import { getDefaultRateLimitRulesApiV1AdminRateLimitsDefaultsGet } from '$lib/api';
 
 vi.mock('$lib/admin/rate-limits', () => ({
     getGroupColor: vi.fn(() => 'badge-neutral'),
@@ -67,7 +54,23 @@ function renderModal(overrides: Record<string, unknown> = {}) {
 }
 
 describe('RateLimitsModal', () => {
-    beforeEach(() => vi.clearAllMocks());
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getDefaultRateLimitRulesApiV1AdminRateLimitsDefaultsGet).mockResolvedValue({
+            data: [
+                {
+                    endpoint_pattern: '/api/v1/*',
+                    requests: 100,
+                    window_seconds: 60,
+                    group: 'api',
+                    algorithm: 'sliding_window',
+                    burst_multiplier: 1.5,
+                    priority: 0,
+                    enabled: true,
+                },
+            ],
+        } as any);
+    });
 
     it('does not render content when open is false', () => {
         renderModal({ open: false });

--- a/frontend/src/components/editor/__tests__/OutputPanel.test.ts
+++ b/frontend/src/components/editor/__tests__/OutputPanel.test.ts
@@ -34,8 +34,6 @@ function renderIdle(overrides: Partial<IdleProps> = {}) {
 describe('OutputPanel', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        vi.spyOn(toast, 'success');
-        vi.spyOn(toast, 'error');
     });
 
     it('shows heading and prompt text when idle with no result or error', () => {

--- a/frontend/src/lib/__tests__/api-interceptors.test.ts
+++ b/frontend/src/lib/__tests__/api-interceptors.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getErrorMessage, unwrap, unwrapOr } from '$lib/api-interceptors';
+
+const { getErrorMessage, unwrap, unwrapOr } =
+    await vi.importActual<typeof import('$lib/api-interceptors')>('$lib/api-interceptors');
 
 describe('getErrorMessage', () => {
     it.each([
@@ -116,6 +118,7 @@ describe('initializeApiInterceptors', () => {
         vi.doMock('svelte-sonner', () => ({ toast: mockToast }));
         vi.doMock('@mateothegreat/svelte5-router', () => ({ goto: mockGoto }));
         vi.doMock('$stores/auth.svelte', () => ({ authStore: mockAuthStore }));
+        vi.doUnmock('$lib/api-interceptors');
 
         const mod = await import('$lib/api-interceptors');
         mod.initializeApiInterceptors();

--- a/frontend/src/lib/__tests__/user-settings.test.ts
+++ b/frontend/src/lib/__tests__/user-settings.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 const mockGetUserSettings = vi.fn();
 const mockUpdateUserSettings = vi.fn();
 
-vi.mock('../api', () => ({
+vi.mock('$lib/api', () => ({
     getUserSettingsApiV1UserSettingsGet: (...args: unknown[]) =>
         (mockGetUserSettings as (...a: unknown[]) => unknown)(...args),
     updateUserSettingsApiV1UserSettingsPut: (...args: unknown[]) =>
@@ -12,13 +12,13 @@ vi.mock('../api', () => ({
 
 const mockSetUserSettings = vi.fn();
 
-vi.mock('../../stores/userSettings.svelte', () => ({
+vi.mock('$stores/userSettings.svelte', () => ({
     setUserSettings: (settings: unknown) => mockSetUserSettings(settings),
 }));
 
 const mockSetTheme = vi.fn();
 
-vi.mock('../../stores/theme.svelte', () => ({
+vi.mock('$stores/theme.svelte', () => ({
     setTheme: (theme: string) => mockSetTheme(theme),
 }));
 
@@ -26,11 +26,11 @@ const mockAuthStore = {
     isAuthenticated: true as boolean | null,
 };
 
-vi.mock('../../stores/auth.svelte', () => ({
+vi.mock('$stores/auth.svelte', () => ({
     authStore: mockAuthStore,
 }));
 
-vi.mock('../api-interceptors', () => ({}));
+vi.mock('$lib/api-interceptors', () => ({}));
 
 describe('user-settings', () => {
     beforeEach(async () => {

--- a/frontend/src/lib/admin/__tests__/pagination.test.ts
+++ b/frontend/src/lib/admin/__tests__/pagination.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 
-const { createPaginationState } = await import('../pagination.svelte');
+const { createPaginationState } = await import('$lib/admin/pagination.svelte');
 
 describe('createPaginationState', () => {
     describe('defaults', () => {

--- a/frontend/src/lib/admin/stores/__tests__/eventsStore.test.ts
+++ b/frontend/src/lib/admin/stores/__tests__/eventsStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { effect_root } from 'svelte/internal/client';
 import { createMockEvent, createMockStats } from '$test/test-utils';
+import { toast } from 'svelte-sonner';
 
 const mocks = vi.hoisted(() => ({
     browseEventsApiV1AdminEventsBrowsePost: vi.fn(),
@@ -11,9 +12,6 @@ const mocks = vi.hoisted(() => ({
     getUserOverviewApiV1AdminUsersUserIdOverviewGet: vi.fn(),
     unwrap: vi.fn((result: { data: unknown }) => result?.data),
     unwrapOr: vi.fn((result: { data: unknown }, fallback: unknown) => result?.data ?? fallback),
-    toastSuccess: vi.fn(),
-    toastError: vi.fn(),
-    toastInfo: vi.fn(),
     windowOpen: vi.fn(),
     windowConfirm: vi.fn(),
 }));
@@ -35,15 +33,6 @@ vi.mock('$lib/api', () => ({
 vi.mock('$lib/api-interceptors', () => ({
     unwrap: (result: { data: unknown }) => mocks.unwrap(result),
     unwrapOr: (result: { data: unknown }, fallback: unknown) => mocks.unwrapOr(result, fallback),
-}));
-
-vi.mock('svelte-sonner', () => ({
-    toast: {
-        success: (...args: unknown[]) => mocks.toastSuccess(...args),
-        error: (...args: unknown[]) => mocks.toastError(...args),
-        info: (...args: unknown[]) => mocks.toastInfo(...args),
-        warning: vi.fn(),
-    },
 }));
 
 type EventSourceHandler = ((event: MessageEvent) => void) | null;
@@ -77,7 +66,7 @@ class MockEventSource {
     }
 }
 
-const { createEventsStore } = await import('../eventsStore.svelte');
+const { createEventsStore } = await import('$lib/admin/stores/eventsStore.svelte');
 
 describe('EventsStore', () => {
     let store: ReturnType<typeof createEventsStore>;
@@ -223,7 +212,7 @@ describe('EventsStore', () => {
             await store.replayEvent('evt-1', false);
 
             expect(mocks.windowConfirm).toHaveBeenCalled();
-            expect(mocks.toastSuccess).toHaveBeenCalledWith(expect.stringContaining('Replay scheduled'));
+            expect(vi.mocked(toast.success)).toHaveBeenCalledWith(expect.stringContaining('Replay scheduled'));
             expect(store.activeReplaySession).toBeTruthy();
             expect(MockEventSource.instances).toHaveLength(1);
             expect(MockEventSource.instances[0]!.url).toBe('/api/v1/admin/events/replay/session-1/status');
@@ -279,7 +268,7 @@ describe('EventsStore', () => {
                 }),
             );
 
-            expect(mocks.toastSuccess).toHaveBeenCalledWith(expect.stringContaining('Replay completed'));
+            expect(vi.mocked(toast.success)).toHaveBeenCalledWith(expect.stringContaining('Replay completed'));
             expect(es.closed).toBe(true);
         });
 
@@ -304,7 +293,7 @@ describe('EventsStore', () => {
             expect(mocks.deleteEventApiV1AdminEventsEventIdDelete).toHaveBeenCalledWith({
                 path: { event_id: 'evt-1' },
             });
-            expect(mocks.toastSuccess).toHaveBeenCalledWith('Event deleted successfully');
+            expect(vi.mocked(toast.success)).toHaveBeenCalledWith('Event deleted successfully');
         });
 
         it('does not delete if confirm is cancelled', async () => {
@@ -326,7 +315,7 @@ describe('EventsStore', () => {
                 expect.stringContaining('/api/v1/admin/events/export/csv'),
                 '_blank',
             );
-            expect(mocks.toastInfo).toHaveBeenCalledWith(expect.stringContaining('CSV'));
+            expect(vi.mocked(toast.info)).toHaveBeenCalledWith(expect.stringContaining('CSV'));
         });
 
         it('opens export URL for JSON', () => {

--- a/frontend/src/lib/admin/stores/__tests__/eventsStore.test.ts
+++ b/frontend/src/lib/admin/stores/__tests__/eventsStore.test.ts
@@ -1,39 +1,19 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { effect_root } from 'svelte/internal/client';
-import { createMockEvent, createMockStats } from '$test/test-utils';
+import { createMockEvent, createMockStats, mockApi } from '$test/test-utils';
 import { toast } from 'svelte-sonner';
+import {
+    browseEventsApiV1AdminEventsBrowsePost,
+    getEventStatsApiV1AdminEventsStatsGet,
+    getEventDetailApiV1AdminEventsEventIdGet,
+    replayEventsApiV1AdminEventsReplayPost,
+    deleteEventApiV1AdminEventsEventIdDelete,
+    getUserOverviewApiV1AdminUsersUserIdOverviewGet,
+} from '$lib/api';
+import { createEventsStore } from '$lib/admin/stores/eventsStore.svelte';
 
-const mocks = vi.hoisted(() => ({
-    browseEventsApiV1AdminEventsBrowsePost: vi.fn(),
-    getEventStatsApiV1AdminEventsStatsGet: vi.fn(),
-    getEventDetailApiV1AdminEventsEventIdGet: vi.fn(),
-    replayEventsApiV1AdminEventsReplayPost: vi.fn(),
-    deleteEventApiV1AdminEventsEventIdDelete: vi.fn(),
-    getUserOverviewApiV1AdminUsersUserIdOverviewGet: vi.fn(),
-    unwrap: vi.fn((result: { data: unknown }) => result?.data),
-    unwrapOr: vi.fn((result: { data: unknown }, fallback: unknown) => result?.data ?? fallback),
-    windowOpen: vi.fn(),
-    windowConfirm: vi.fn(),
-}));
-
-vi.mock('$lib/api', () => ({
-    browseEventsApiV1AdminEventsBrowsePost: (...args: unknown[]) =>
-        mocks.browseEventsApiV1AdminEventsBrowsePost(...args),
-    getEventStatsApiV1AdminEventsStatsGet: (...args: unknown[]) => mocks.getEventStatsApiV1AdminEventsStatsGet(...args),
-    getEventDetailApiV1AdminEventsEventIdGet: (...args: unknown[]) =>
-        mocks.getEventDetailApiV1AdminEventsEventIdGet(...args),
-    replayEventsApiV1AdminEventsReplayPost: (...args: unknown[]) =>
-        mocks.replayEventsApiV1AdminEventsReplayPost(...args),
-    deleteEventApiV1AdminEventsEventIdDelete: (...args: unknown[]) =>
-        mocks.deleteEventApiV1AdminEventsEventIdDelete(...args),
-    getUserOverviewApiV1AdminUsersUserIdOverviewGet: (...args: unknown[]) =>
-        mocks.getUserOverviewApiV1AdminUsersUserIdOverviewGet(...args),
-}));
-
-vi.mock('$lib/api-interceptors', () => ({
-    unwrap: (result: { data: unknown }) => mocks.unwrap(result),
-    unwrapOr: (result: { data: unknown }, fallback: unknown) => mocks.unwrapOr(result, fallback),
-}));
+const windowOpen = vi.fn();
+const windowConfirm = vi.fn();
 
 type EventSourceHandler = ((event: MessageEvent) => void) | null;
 
@@ -66,8 +46,6 @@ class MockEventSource {
     }
 }
 
-const { createEventsStore } = await import('$lib/admin/stores/eventsStore.svelte');
-
 describe('EventsStore', () => {
     let store: ReturnType<typeof createEventsStore>;
     let teardown: () => void;
@@ -76,15 +54,11 @@ describe('EventsStore', () => {
         vi.clearAllMocks();
         MockEventSource.instances = [];
         vi.stubGlobal('EventSource', MockEventSource);
-        vi.stubGlobal('open', mocks.windowOpen);
-        vi.stubGlobal('confirm', mocks.windowConfirm);
-        mocks.windowConfirm.mockReturnValue(true);
-        mocks.browseEventsApiV1AdminEventsBrowsePost.mockResolvedValue({
-            data: { events: [], total: 0 },
-        });
-        mocks.getEventStatsApiV1AdminEventsStatsGet.mockResolvedValue({
-            data: null,
-        });
+        vi.stubGlobal('open', windowOpen);
+        vi.stubGlobal('confirm', windowConfirm);
+        windowConfirm.mockReturnValue(true);
+        mockApi(browseEventsApiV1AdminEventsBrowsePost).ok({ events: [], total: 0 });
+        mockApi(getEventStatsApiV1AdminEventsStatsGet).ok(null);
     });
 
     function createStore() {
@@ -114,12 +88,8 @@ describe('EventsStore', () => {
         it('loads events and stats', async () => {
             const events = [createMockEvent()];
             const stats = createMockStats();
-            mocks.browseEventsApiV1AdminEventsBrowsePost.mockResolvedValue({
-                data: { events, total: 1 },
-            });
-            mocks.getEventStatsApiV1AdminEventsStatsGet.mockResolvedValue({
-                data: stats,
-            });
+            mockApi(browseEventsApiV1AdminEventsBrowsePost).ok({ events, total: 1 });
+            mockApi(getEventStatsApiV1AdminEventsStatsGet).ok(stats);
 
             createStore();
             await store.loadAll();
@@ -136,7 +106,7 @@ describe('EventsStore', () => {
             store.pagination.currentPage = 2;
             await store.loadEvents();
 
-            expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalledWith(
+            expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalledWith(
                 expect.objectContaining({
                     body: expect.objectContaining({ skip: 10, limit: 10 }),
                 }),
@@ -148,7 +118,7 @@ describe('EventsStore', () => {
             store.filters = { user_id: 'user-1', aggregate_id: 'agg-1' };
             await store.loadEvents();
 
-            expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalledWith(
+            expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalledWith(
                 expect.objectContaining({
                     body: expect.objectContaining({
                         filters: expect.objectContaining({
@@ -161,7 +131,7 @@ describe('EventsStore', () => {
         });
 
         it('handles empty response', async () => {
-            mocks.browseEventsApiV1AdminEventsBrowsePost.mockResolvedValue({ data: null });
+            mockApi(browseEventsApiV1AdminEventsBrowsePost).ok(undefined);
 
             createStore();
             await store.loadEvents();
@@ -174,13 +144,13 @@ describe('EventsStore', () => {
     describe('loadEventDetail', () => {
         it('returns event detail', async () => {
             const detail = { event: createMockEvent(), related_events: [], timeline: [] };
-            mocks.getEventDetailApiV1AdminEventsEventIdGet.mockResolvedValue({ data: detail });
+            mockApi(getEventDetailApiV1AdminEventsEventIdGet).ok(detail);
 
             createStore();
             const result = await store.loadEventDetail('evt-1');
 
             expect(result).toEqual(detail);
-            expect(mocks.getEventDetailApiV1AdminEventsEventIdGet).toHaveBeenCalledWith({
+            expect(vi.mocked(getEventDetailApiV1AdminEventsEventIdGet)).toHaveBeenCalledWith({
                 path: { event_id: 'evt-1' },
             });
         });
@@ -189,8 +159,9 @@ describe('EventsStore', () => {
     describe('replayEvent', () => {
         it('performs dry run and sets replayPreview', async () => {
             const preview = [createMockEvent()];
-            mocks.replayEventsApiV1AdminEventsReplayPost.mockResolvedValue({
-                data: { total_events: 1, events_preview: preview },
+            mockApi(replayEventsApiV1AdminEventsReplayPost).ok({
+                total_events: 1,
+                events_preview: preview,
             });
 
             createStore();
@@ -204,14 +175,16 @@ describe('EventsStore', () => {
         });
 
         it('confirms and starts SSE stream for actual replay', async () => {
-            mocks.replayEventsApiV1AdminEventsReplayPost.mockResolvedValue({
-                data: { total_events: 1, session_id: 'session-1', replay_id: 'replay-1' },
+            mockApi(replayEventsApiV1AdminEventsReplayPost).ok({
+                total_events: 1,
+                session_id: 'session-1',
+                replay_id: 'replay-1',
             });
 
             createStore();
             await store.replayEvent('evt-1', false);
 
-            expect(mocks.windowConfirm).toHaveBeenCalled();
+            expect(windowConfirm).toHaveBeenCalled();
             expect(vi.mocked(toast.success)).toHaveBeenCalledWith(expect.stringContaining('Replay scheduled'));
             expect(store.activeReplaySession).toBeTruthy();
             expect(MockEventSource.instances).toHaveLength(1);
@@ -219,8 +192,10 @@ describe('EventsStore', () => {
         });
 
         it('updates activeReplaySession from SSE messages', async () => {
-            mocks.replayEventsApiV1AdminEventsReplayPost.mockResolvedValue({
-                data: { total_events: 5, session_id: 'session-1', replay_id: 'replay-1' },
+            mockApi(replayEventsApiV1AdminEventsReplayPost).ok({
+                total_events: 5,
+                session_id: 'session-1',
+                replay_id: 'replay-1',
             });
 
             createStore();
@@ -246,8 +221,10 @@ describe('EventsStore', () => {
         });
 
         it('disconnects SSE on terminal status', async () => {
-            mocks.replayEventsApiV1AdminEventsReplayPost.mockResolvedValue({
-                data: { total_events: 5, session_id: 'session-1', replay_id: 'replay-1' },
+            mockApi(replayEventsApiV1AdminEventsReplayPost).ok({
+                total_events: 5,
+                session_id: 'session-1',
+                replay_id: 'replay-1',
             });
 
             createStore();
@@ -273,36 +250,36 @@ describe('EventsStore', () => {
         });
 
         it('does not replay if confirm is cancelled', async () => {
-            mocks.windowConfirm.mockReturnValue(false);
+            windowConfirm.mockReturnValue(false);
 
             createStore();
             await store.replayEvent('evt-1', false);
 
-            expect(mocks.replayEventsApiV1AdminEventsReplayPost).not.toHaveBeenCalled();
+            expect(vi.mocked(replayEventsApiV1AdminEventsReplayPost)).not.toHaveBeenCalled();
         });
     });
 
     describe('deleteEvent', () => {
         it('confirms and deletes event', async () => {
-            mocks.deleteEventApiV1AdminEventsEventIdDelete.mockResolvedValue({ data: {} });
+            mockApi(deleteEventApiV1AdminEventsEventIdDelete).ok({});
 
             createStore();
             await store.deleteEvent('evt-1');
 
-            expect(mocks.windowConfirm).toHaveBeenCalled();
-            expect(mocks.deleteEventApiV1AdminEventsEventIdDelete).toHaveBeenCalledWith({
+            expect(windowConfirm).toHaveBeenCalled();
+            expect(vi.mocked(deleteEventApiV1AdminEventsEventIdDelete)).toHaveBeenCalledWith({
                 path: { event_id: 'evt-1' },
             });
             expect(vi.mocked(toast.success)).toHaveBeenCalledWith('Event deleted successfully');
         });
 
         it('does not delete if confirm is cancelled', async () => {
-            mocks.windowConfirm.mockReturnValue(false);
+            windowConfirm.mockReturnValue(false);
 
             createStore();
             await store.deleteEvent('evt-1');
 
-            expect(mocks.deleteEventApiV1AdminEventsEventIdDelete).not.toHaveBeenCalled();
+            expect(vi.mocked(deleteEventApiV1AdminEventsEventIdDelete)).not.toHaveBeenCalled();
         });
     });
 
@@ -311,7 +288,7 @@ describe('EventsStore', () => {
             createStore();
             store.exportEvents('csv');
 
-            expect(mocks.windowOpen).toHaveBeenCalledWith(
+            expect(windowOpen).toHaveBeenCalledWith(
                 expect.stringContaining('/api/v1/admin/events/export/csv'),
                 '_blank',
             );
@@ -322,7 +299,7 @@ describe('EventsStore', () => {
             createStore();
             store.exportEvents('json');
 
-            expect(mocks.windowOpen).toHaveBeenCalledWith(
+            expect(windowOpen).toHaveBeenCalledWith(
                 expect.stringContaining('/api/v1/admin/events/export/json'),
                 '_blank',
             );
@@ -333,16 +310,14 @@ describe('EventsStore', () => {
             store.filters = { user_id: 'user-1', aggregate_id: 'agg-1' };
             store.exportEvents('csv');
 
-            expect(mocks.windowOpen).toHaveBeenCalledWith(expect.stringMatching(/user_id=user-1/), '_blank');
+            expect(windowOpen).toHaveBeenCalledWith(expect.stringMatching(/user_id=user-1/), '_blank');
         });
     });
 
     describe('openUserOverview', () => {
         it('loads user overview', async () => {
             const overview = { user: { user_id: 'user-1' }, stats: {}, derived_counts: {} };
-            mocks.getUserOverviewApiV1AdminUsersUserIdOverviewGet.mockResolvedValue({
-                data: overview,
-            });
+            mockApi(getUserOverviewApiV1AdminUsersUserIdOverviewGet).ok(overview);
 
             createStore();
             await store.openUserOverview('user-1');
@@ -355,7 +330,7 @@ describe('EventsStore', () => {
             createStore();
             await store.openUserOverview('');
 
-            expect(mocks.getUserOverviewApiV1AdminUsersUserIdOverviewGet).not.toHaveBeenCalled();
+            expect(vi.mocked(getUserOverviewApiV1AdminUsersUserIdOverviewGet)).not.toHaveBeenCalled();
         });
     });
 
@@ -369,7 +344,7 @@ describe('EventsStore', () => {
 
             expect(store.filters).toEqual({});
             expect(store.pagination.currentPage).toBe(1);
-            expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalled();
+            expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalled();
         });
     });
 
@@ -379,29 +354,31 @@ describe('EventsStore', () => {
             vi.clearAllMocks();
 
             await vi.advanceTimersByTimeAsync(30000);
-            expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalledTimes(1);
+            expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalledTimes(1);
 
             await vi.advanceTimersByTimeAsync(30000);
-            expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalledTimes(2);
+            expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalledTimes(2);
         });
 
         it('stops on teardown', async () => {
             createStore();
             await vi.advanceTimersByTimeAsync(30000);
-            expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalled();
+            expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalled();
 
-            const callsBefore = mocks.browseEventsApiV1AdminEventsBrowsePost.mock.calls.length;
+            const callsBefore = vi.mocked(browseEventsApiV1AdminEventsBrowsePost).mock.calls.length;
             teardown();
 
             await vi.advanceTimersByTimeAsync(60000);
-            expect(mocks.browseEventsApiV1AdminEventsBrowsePost.mock.calls.length).toBe(callsBefore);
+            expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost).mock.calls.length).toBe(callsBefore);
         });
     });
 
     describe('cleanup', () => {
         it('cleans up SSE replay stream', async () => {
-            mocks.replayEventsApiV1AdminEventsReplayPost.mockResolvedValue({
-                data: { total_events: 1, session_id: 'session-1', replay_id: 'replay-1' },
+            mockApi(replayEventsApiV1AdminEventsReplayPost).ok({
+                total_events: 1,
+                session_id: 'session-1',
+                replay_id: 'replay-1',
             });
 
             createStore();

--- a/frontend/src/lib/admin/stores/__tests__/executionsStore.test.ts
+++ b/frontend/src/lib/admin/stores/__tests__/executionsStore.test.ts
@@ -1,41 +1,24 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { effect_root } from 'svelte/internal/client';
-import { createMockExecution, createMockQueueStatus } from '$test/test-utils';
+import { createMockExecution, createMockQueueStatus, mockApi } from '$test/test-utils';
 import { toast } from 'svelte-sonner';
-
-const mocks = vi.hoisted(() => ({
-    listExecutionsApiV1AdminExecutionsGet: vi.fn(),
-    updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut: vi.fn(),
-    getQueueStatusApiV1AdminExecutionsQueueGet: vi.fn(),
-    unwrap: vi.fn((result: { data: unknown }) => result?.data),
-    unwrapOr: vi.fn((result: { data: unknown }, fallback: unknown) => result?.data ?? fallback),
-}));
-
-vi.mock('$lib/api', () => ({
-    listExecutionsApiV1AdminExecutionsGet: (...args: unknown[]) => mocks.listExecutionsApiV1AdminExecutionsGet(...args),
-    updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut: (...args: unknown[]) =>
-        mocks.updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut(...args),
-    getQueueStatusApiV1AdminExecutionsQueueGet: (...args: unknown[]) =>
-        mocks.getQueueStatusApiV1AdminExecutionsQueueGet(...args),
-}));
-
-vi.mock('$lib/api-interceptors', () => ({
-    unwrap: (result: { data: unknown }) => mocks.unwrap(result),
-    unwrapOr: (result: { data: unknown }, fallback: unknown) => mocks.unwrapOr(result, fallback),
-}));
-
-const { createExecutionsStore } = await import('$lib/admin/stores/executionsStore.svelte');
+import {
+    listExecutionsApiV1AdminExecutionsGet,
+    updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut,
+    getQueueStatusApiV1AdminExecutionsQueueGet,
+} from '$lib/api';
+import { createExecutionsStore } from '$lib/admin/stores/executionsStore.svelte';
 
 function setupDefaultMocks() {
-    mocks.listExecutionsApiV1AdminExecutionsGet.mockResolvedValue({
-        data: { executions: [], total: 0, limit: 20, skip: 0, has_more: false },
+    mockApi(listExecutionsApiV1AdminExecutionsGet).ok({
+        executions: [],
+        total: 0,
+        limit: 20,
+        skip: 0,
+        has_more: false,
     });
-    mocks.getQueueStatusApiV1AdminExecutionsQueueGet.mockResolvedValue({
-        data: createMockQueueStatus(),
-    });
-    mocks.updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut.mockResolvedValue({
-        data: null,
-    });
+    mockApi(getQueueStatusApiV1AdminExecutionsQueueGet).ok(createMockQueueStatus());
+    mockApi(updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut).ok(null);
 }
 
 describe('ExecutionsStore', () => {
@@ -94,12 +77,8 @@ describe('ExecutionsStore', () => {
         it('loads executions and queue status', async () => {
             createStore();
             const execs = [createMockExecution()];
-            mocks.listExecutionsApiV1AdminExecutionsGet.mockResolvedValue({
-                data: { executions: execs, total: 1 },
-            });
-            mocks.getQueueStatusApiV1AdminExecutionsQueueGet.mockResolvedValue({
-                data: createMockQueueStatus(),
-            });
+            mockApi(listExecutionsApiV1AdminExecutionsGet).ok({ executions: execs, total: 1 });
+            mockApi(getQueueStatusApiV1AdminExecutionsQueueGet).ok(createMockQueueStatus());
 
             await store.loadData();
 
@@ -110,7 +89,7 @@ describe('ExecutionsStore', () => {
 
         it('handles empty API response', async () => {
             createStore();
-            mocks.listExecutionsApiV1AdminExecutionsGet.mockResolvedValue({ data: null });
+            mockApi(listExecutionsApiV1AdminExecutionsGet).ok(undefined);
 
             await store.loadExecutions();
 
@@ -125,7 +104,7 @@ describe('ExecutionsStore', () => {
             store.statusFilter = 'running';
             await store.loadExecutions();
 
-            expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledWith(
+            expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledWith(
                 expect.objectContaining({
                     query: expect.objectContaining({ status: 'running' }),
                 }),
@@ -137,7 +116,7 @@ describe('ExecutionsStore', () => {
             store.priorityFilter = 'high';
             await store.loadExecutions();
 
-            expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledWith(
+            expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledWith(
                 expect.objectContaining({
                     query: expect.objectContaining({ priority: 'high' }),
                 }),
@@ -149,7 +128,7 @@ describe('ExecutionsStore', () => {
             store.userSearch = 'user-42';
             await store.loadExecutions();
 
-            expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledWith(
+            expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledWith(
                 expect.objectContaining({
                     query: expect.objectContaining({ user_id: 'user-42' }),
                 }),
@@ -160,7 +139,7 @@ describe('ExecutionsStore', () => {
             createStore();
             await store.loadExecutions();
 
-            expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledWith(
+            expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledWith(
                 expect.objectContaining({
                     query: expect.objectContaining({
                         status: undefined,
@@ -177,7 +156,7 @@ describe('ExecutionsStore', () => {
             createStore();
             await store.updatePriority('exec-1', 'high');
 
-            expect(mocks.updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut).toHaveBeenCalledWith({
+            expect(vi.mocked(updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut)).toHaveBeenCalledWith({
                 path: { execution_id: 'exec-1' },
                 body: { priority: 'high' },
             });
@@ -207,10 +186,10 @@ describe('ExecutionsStore', () => {
             setupDefaultMocks();
 
             await vi.advanceTimersByTimeAsync(5000);
-            expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledTimes(1);
+            expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledTimes(1);
 
             await vi.advanceTimersByTimeAsync(5000);
-            expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledTimes(2);
+            expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledTimes(2);
         });
 
         it('stops on teardown', async () => {
@@ -218,14 +197,14 @@ describe('ExecutionsStore', () => {
             setupDefaultMocks();
 
             await vi.advanceTimersByTimeAsync(5000);
-            expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalled();
+            expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalled();
 
-            const callsBefore = mocks.listExecutionsApiV1AdminExecutionsGet.mock.calls.length;
+            const callsBefore = vi.mocked(listExecutionsApiV1AdminExecutionsGet).mock.calls.length;
             teardown();
             vi.clearAllTimers();
 
             await vi.advanceTimersByTimeAsync(10000);
-            expect(mocks.listExecutionsApiV1AdminExecutionsGet.mock.calls.length).toBe(callsBefore);
+            expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet).mock.calls.length).toBe(callsBefore);
         });
     });
 
@@ -235,7 +214,7 @@ describe('ExecutionsStore', () => {
             store.pagination.currentPage = 2;
             await store.loadExecutions();
 
-            expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledWith(
+            expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledWith(
                 expect.objectContaining({
                     query: expect.objectContaining({
                         skip: 20,

--- a/frontend/src/lib/admin/stores/__tests__/executionsStore.test.ts
+++ b/frontend/src/lib/admin/stores/__tests__/executionsStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { effect_root } from 'svelte/internal/client';
 import { createMockExecution, createMockQueueStatus } from '$test/test-utils';
+import { toast } from 'svelte-sonner';
 
 const mocks = vi.hoisted(() => ({
     listExecutionsApiV1AdminExecutionsGet: vi.fn(),
@@ -8,7 +9,6 @@ const mocks = vi.hoisted(() => ({
     getQueueStatusApiV1AdminExecutionsQueueGet: vi.fn(),
     unwrap: vi.fn((result: { data: unknown }) => result?.data),
     unwrapOr: vi.fn((result: { data: unknown }, fallback: unknown) => result?.data ?? fallback),
-    toastSuccess: vi.fn(),
 }));
 
 vi.mock('$lib/api', () => ({
@@ -24,16 +24,7 @@ vi.mock('$lib/api-interceptors', () => ({
     unwrapOr: (result: { data: unknown }, fallback: unknown) => mocks.unwrapOr(result, fallback),
 }));
 
-vi.mock('svelte-sonner', () => ({
-    toast: {
-        success: (...args: unknown[]) => mocks.toastSuccess(...args),
-        error: vi.fn(),
-        info: vi.fn(),
-        warning: vi.fn(),
-    },
-}));
-
-const { createExecutionsStore } = await import('../executionsStore.svelte');
+const { createExecutionsStore } = await import('$lib/admin/stores/executionsStore.svelte');
 
 function setupDefaultMocks() {
     mocks.listExecutionsApiV1AdminExecutionsGet.mockResolvedValue({
@@ -190,7 +181,7 @@ describe('ExecutionsStore', () => {
                 path: { execution_id: 'exec-1' },
                 body: { priority: 'high' },
             });
-            expect(mocks.toastSuccess).toHaveBeenCalledWith('Priority updated to high');
+            expect(vi.mocked(toast.success)).toHaveBeenCalledWith('Priority updated to high');
         });
     });
 

--- a/frontend/src/lib/admin/stores/__tests__/sagasStore.test.ts
+++ b/frontend/src/lib/admin/stores/__tests__/sagasStore.test.ts
@@ -15,7 +15,7 @@ vi.mock('$lib/api-interceptors', () => ({
     unwrapOr: (result: { data: unknown }, fallback: unknown) => mocks.unwrapOr(result, fallback),
 }));
 
-const { createSagasStore } = await import('../sagasStore.svelte');
+const { createSagasStore } = await import('$lib/admin/stores/sagasStore.svelte');
 
 describe('SagasStore', () => {
     let store: ReturnType<typeof createSagasStore>;

--- a/frontend/src/lib/admin/stores/__tests__/sagasStore.test.ts
+++ b/frontend/src/lib/admin/stores/__tests__/sagasStore.test.ts
@@ -1,21 +1,8 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { effect_root } from 'svelte/internal/client';
-import { createMockSaga } from '$test/test-utils';
-
-const mocks = vi.hoisted(() => ({
-    listSagasApiV1SagasGet: vi.fn(),
-    unwrapOr: vi.fn((result: { data: unknown }, fallback: unknown) => result?.data ?? fallback),
-}));
-
-vi.mock('$lib/api', () => ({
-    listSagasApiV1SagasGet: (...args: unknown[]) => mocks.listSagasApiV1SagasGet(...args),
-}));
-
-vi.mock('$lib/api-interceptors', () => ({
-    unwrapOr: (result: { data: unknown }, fallback: unknown) => mocks.unwrapOr(result, fallback),
-}));
-
-const { createSagasStore } = await import('$lib/admin/stores/sagasStore.svelte');
+import { createMockSaga, mockApi } from '$test/test-utils';
+import { listSagasApiV1SagasGet } from '$lib/api';
+import { createSagasStore } from '$lib/admin/stores/sagasStore.svelte';
 
 describe('SagasStore', () => {
     let store: ReturnType<typeof createSagasStore>;
@@ -23,9 +10,7 @@ describe('SagasStore', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        mocks.listSagasApiV1SagasGet.mockResolvedValue({
-            data: { sagas: [], total: 0 },
-        });
+        mockApi(listSagasApiV1SagasGet).ok({ sagas: [], total: 0 });
     });
 
     function createStore() {
@@ -57,9 +42,7 @@ describe('SagasStore', () => {
     describe('loadSagas', () => {
         it('loads sagas from API', async () => {
             const sagas = [createMockSaga()];
-            mocks.listSagasApiV1SagasGet.mockResolvedValue({
-                data: { sagas, total: 1 },
-            });
+            mockApi(listSagasApiV1SagasGet).ok({ sagas, total: 1 });
 
             createStore();
             await store.loadSagas();
@@ -70,7 +53,7 @@ describe('SagasStore', () => {
         });
 
         it('handles empty API response', async () => {
-            mocks.listSagasApiV1SagasGet.mockResolvedValue({ data: null });
+            mockApi(listSagasApiV1SagasGet).ok(undefined);
 
             createStore();
             await store.loadSagas();
@@ -84,7 +67,7 @@ describe('SagasStore', () => {
             store.stateFilter = 'running';
             await store.loadSagas();
 
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledWith(
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledWith(
                 expect.objectContaining({
                     query: expect.objectContaining({ state: 'running' }),
                 }),
@@ -96,7 +79,7 @@ describe('SagasStore', () => {
             store.pagination.currentPage = 3;
             await store.loadSagas();
 
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledWith(
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledWith(
                 expect.objectContaining({
                     query: expect.objectContaining({ skip: 20, limit: 10 }),
                 }),
@@ -107,15 +90,13 @@ describe('SagasStore', () => {
     describe('client-side filtering', () => {
         it('passes execution_id filter as query param', async () => {
             const sagas = [createMockSaga({ saga_id: 's1', execution_id: 'exec-abc' })];
-            mocks.listSagasApiV1SagasGet.mockResolvedValue({
-                data: { sagas, total: 1 },
-            });
+            mockApi(listSagasApiV1SagasGet).ok({ sagas, total: 1 });
 
             createStore();
             store.executionIdFilter = 'exec-abc';
             await store.loadSagas();
 
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledWith(
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledWith(
                 expect.objectContaining({
                     query: expect.objectContaining({ execution_id: 'exec-abc' }),
                 }),
@@ -128,9 +109,7 @@ describe('SagasStore', () => {
                 createMockSaga({ saga_id: 's1', saga_name: 'alpha_saga' }),
                 createMockSaga({ saga_id: 's2', saga_name: 'beta_saga' }),
             ];
-            mocks.listSagasApiV1SagasGet.mockResolvedValue({
-                data: { sagas, total: 2 },
-            });
+            mockApi(listSagasApiV1SagasGet).ok({ sagas, total: 2 });
 
             createStore();
             store.searchQuery = 'alpha';
@@ -152,16 +131,14 @@ describe('SagasStore', () => {
     describe('loadExecutionSagas', () => {
         it('sets filter and delegates to loadSagas with execution_id query param', async () => {
             const sagas = [createMockSaga({ execution_id: 'exec-target' })];
-            mocks.listSagasApiV1SagasGet.mockResolvedValue({
-                data: { sagas, total: 1 },
-            });
+            mockApi(listSagasApiV1SagasGet).ok({ sagas, total: 1 });
 
             createStore();
             await store.loadExecutionSagas('exec-target');
 
             expect(store.executionIdFilter).toBe('exec-target');
             expect(store.pagination.currentPage).toBe(1);
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledWith(
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledWith(
                 expect.objectContaining({
                     query: expect.objectContaining({ execution_id: 'exec-target' }),
                 }),
@@ -184,7 +161,7 @@ describe('SagasStore', () => {
             expect(store.executionIdFilter).toBe('');
             expect(store.searchQuery).toBe('');
             expect(store.pagination.currentPage).toBe(1);
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalled();
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalled();
         });
     });
 
@@ -194,29 +171,25 @@ describe('SagasStore', () => {
             vi.clearAllMocks();
 
             await vi.advanceTimersByTimeAsync(5000);
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledTimes(1);
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledTimes(1);
 
             await vi.advanceTimersByTimeAsync(5000);
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledTimes(2);
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledTimes(2);
         });
 
         it('passes execution_id on auto-refresh when filter is set', async () => {
             const sagas = [createMockSaga({ execution_id: 'exec-target' })];
-            mocks.listSagasApiV1SagasGet.mockResolvedValue({
-                data: { sagas, total: 1 },
-            });
+            mockApi(listSagasApiV1SagasGet).ok({ sagas, total: 1 });
 
             createStore();
             await store.loadExecutionSagas('exec-target');
             vi.clearAllMocks();
 
-            mocks.listSagasApiV1SagasGet.mockResolvedValue({
-                data: { sagas, total: 1 },
-            });
+            mockApi(listSagasApiV1SagasGet).ok({ sagas, total: 1 });
 
             await vi.advanceTimersByTimeAsync(5000);
 
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledWith(
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledWith(
                 expect.objectContaining({
                     query: expect.objectContaining({ execution_id: 'exec-target' }),
                 }),
@@ -226,13 +199,13 @@ describe('SagasStore', () => {
         it('stops when refreshEnabled set to false', async () => {
             createStore();
             await vi.advanceTimersByTimeAsync(5000);
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalled();
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalled();
 
-            const callsBefore = mocks.listSagasApiV1SagasGet.mock.calls.length;
+            const callsBefore = vi.mocked(listSagasApiV1SagasGet).mock.calls.length;
             store.refreshEnabled = false;
 
             await vi.advanceTimersByTimeAsync(10000);
-            expect(mocks.listSagasApiV1SagasGet.mock.calls.length).toBe(callsBefore);
+            expect(vi.mocked(listSagasApiV1SagasGet).mock.calls.length).toBe(callsBefore);
         });
     });
 });

--- a/frontend/src/lib/editor/__tests__/execution.test.ts
+++ b/frontend/src/lib/editor/__tests__/execution.test.ts
@@ -1,19 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ExecutionResult } from '$lib/api';
+import { createExecutionApiV1ExecutePost, executionEventsApiV1EventsExecutionsExecutionIdGet } from '$lib/api';
+import { createExecutionState } from '$lib/editor/execution.svelte';
 
-const mockCreateExecution = vi.fn();
-const mockSseFn = vi.fn();
-
-vi.mock('$lib/api', () => ({
-    createExecutionApiV1ExecutePost: (...a: unknown[]) => mockCreateExecution(...a),
-    executionEventsApiV1EventsExecutionsExecutionIdGet: (...a: unknown[]) => mockSseFn(...a),
-}));
-
-vi.mock('$lib/api-interceptors', () => ({
-    getErrorMessage: (_err: unknown, fallback: string) => fallback,
-}));
-
-const { createExecutionState } = await import('../execution.svelte');
+const mockCreateExecution = vi.mocked(createExecutionApiV1ExecutePost);
+const mockSseFn = vi.mocked(executionEventsApiV1EventsExecutionsExecutionIdGet);
 
 const RESULT: ExecutionResult = {
     execution_id: 'exec-1',
@@ -32,8 +23,8 @@ function mockSseEvents(...events: unknown[]) {
     mockSseFn.mockResolvedValue({
         stream: (async function* () {
             for (const e of events) yield e;
-        })(),
-    });
+        })() as any,
+    } as any);
 }
 
 describe('createExecutionState', () => {
@@ -58,8 +49,8 @@ describe('createExecutionState', () => {
         it('yields result from SSE stream', async () => {
             mockCreateExecution.mockResolvedValue({
                 data: { execution_id: 'exec-1', status: 'queued' },
-                error: null,
-            });
+                error: undefined,
+            } as any);
 
             mockSseEvents({ event_type: 'status', status: 'running' }, { event_type: 'result_stored', result: RESULT });
 
@@ -74,8 +65,8 @@ describe('createExecutionState', () => {
         it('sets result to null and no error when result_stored has no result', async () => {
             mockCreateExecution.mockResolvedValue({
                 data: { execution_id: 'exec-1', status: 'queued' },
-                error: null,
-            });
+                error: undefined,
+            } as any);
 
             mockSseEvents({ event_type: 'result_stored', result: null });
 
@@ -96,8 +87,8 @@ describe('createExecutionState', () => {
         ] as const)('sets error on %s event', async (eventType, expectedError) => {
             mockCreateExecution.mockResolvedValue({
                 data: { execution_id: 'exec-1', status: 'queued' },
-                error: null,
-            });
+                error: undefined,
+            } as any);
 
             mockSseEvents({ event_type: eventType });
 
@@ -111,8 +102,8 @@ describe('createExecutionState', () => {
         it('uses result from terminal failure event when available', async () => {
             mockCreateExecution.mockResolvedValue({
                 data: { execution_id: 'exec-1', status: 'queued' },
-                error: null,
-            });
+                error: undefined,
+            } as any);
 
             mockSseEvents({ event_type: 'execution_failed', result: RESULT });
 
@@ -128,8 +119,8 @@ describe('createExecutionState', () => {
         it('sets connection lost error', async () => {
             mockCreateExecution.mockResolvedValue({
                 data: { execution_id: 'exec-1', status: 'queued' },
-                error: null,
-            });
+                error: undefined,
+            } as any);
 
             mockSseEvents({ event_type: 'status', status: 'running' });
 
@@ -146,7 +137,7 @@ describe('createExecutionState', () => {
             mockCreateExecution.mockResolvedValue({
                 data: null,
                 error: { detail: 'rate limited' },
-            });
+            } as any);
 
             const s = createExecutionState();
             await s.execute('x', 'python', '3.12');
@@ -166,7 +157,7 @@ describe('createExecutionState', () => {
 
     describe('reset', () => {
         it('clears all state', async () => {
-            mockCreateExecution.mockResolvedValue({ data: null, error: 'fail' });
+            mockCreateExecution.mockResolvedValue({ data: null, error: 'fail' } as any);
 
             const s = createExecutionState();
             await s.execute('x', 'python', '3.12');
@@ -182,8 +173,8 @@ describe('createExecutionState', () => {
         it('skips non-object events and continues', async () => {
             mockCreateExecution.mockResolvedValue({
                 data: { execution_id: 'exec-1', status: 'queued' },
-                error: null,
-            });
+                error: undefined,
+            } as any);
 
             mockSseEvents('{broken', { event_type: 'result_stored', result: RESULT });
 

--- a/frontend/src/lib/editor/__tests__/languages.test.ts
+++ b/frontend/src/lib/editor/__tests__/languages.test.ts
@@ -10,7 +10,6 @@ describe('getLanguageExtension', () => {
     it('returns python extension for unknown language', () => {
         const fallback = getLanguageExtension('unknown-lang');
         const python = getLanguageExtension('python');
-        // Both should return a python() extension — compare structure
         expect(typeof fallback).toBe(typeof python);
     });
 
@@ -22,7 +21,6 @@ describe('getLanguageExtension', () => {
     it('returns distinct extensions for different languages', () => {
         const py = getLanguageExtension('python');
         const js = getLanguageExtension('node');
-        // Different language extensions should not be referentially equal
         expect(py).not.toBe(js);
     });
 });

--- a/frontend/src/lib/notifications/__tests__/stream.test.ts
+++ b/frontend/src/lib/notifications/__tests__/stream.test.ts
@@ -1,15 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { NotificationResponse } from '$lib/api';
+import { notificationStreamApiV1EventsNotificationsStreamGet } from '$lib/api';
+import { notificationStream } from '$lib/notifications/stream.svelte';
 
 type NotificationCallback = (data: NotificationResponse) => void;
 
-const mockSseFn = vi.fn();
-
-vi.mock('$lib/api', () => ({
-    notificationStreamApiV1EventsNotificationsStreamGet: mockSseFn,
-}));
-
-const { notificationStream } = await import('../stream.svelte');
+const mockSseFn = vi.mocked(notificationStreamApiV1EventsNotificationsStreamGet);
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -42,7 +38,7 @@ function mockStream(): { readonly onSseEvent: ((event: any) => void) | undefined
                 yield; // keep generator alive until aborted
                 await new Promise<void>(() => {});
             })(),
-        };
+        } as any;
     });
 
     return {

--- a/frontend/src/routes/__tests__/Editor.test.ts
+++ b/frontend/src/routes/__tests__/Editor.test.ts
@@ -1,28 +1,33 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
-import { user } from '$test/test-utils';
+import { user, mockApi } from '$test/test-utils';
 import { toast } from 'svelte-sonner';
 import * as meta from '$utils/meta';
 import Editor from '$routes/Editor.svelte';
 
 function createMockLimits() {
     return {
-        max_cpu: '1',
-        max_memory: '512Mi',
-        max_timeout: 60,
+        cpu_limit: '1',
+        memory_limit: '512Mi',
+        cpu_request: '0.5',
+        memory_request: '256Mi',
+        execution_timeout: 60,
         supported_runtimes: {
             python: { versions: ['3.11', '3.12'], file_ext: 'py', display_name: 'Python' },
         },
     };
 }
 
+import {
+    getK8sResourceLimitsApiV1K8sLimitsGet,
+    getExampleScriptsApiV1ExampleScriptsGet,
+    listSavedScriptsApiV1ScriptsGet,
+    createSavedScriptApiV1ScriptsPost,
+    updateSavedScriptApiV1ScriptsScriptIdPut,
+    deleteSavedScriptApiV1ScriptsScriptIdDelete,
+} from '$lib/api';
+
 const mocks = vi.hoisted(() => ({
-    getK8sResourceLimitsApiV1K8sLimitsGet: vi.fn(),
-    getExampleScriptsApiV1ExampleScriptsGet: vi.fn(),
-    listSavedScriptsApiV1ScriptsGet: vi.fn(),
-    createSavedScriptApiV1ScriptsPost: vi.fn(),
-    updateSavedScriptApiV1ScriptsScriptIdPut: vi.fn(),
-    deleteSavedScriptApiV1ScriptsScriptIdDelete: vi.fn(),
     mockConfirm: vi.fn(),
     mockExecutionState: {
         phase: 'idle' as string,
@@ -39,25 +44,6 @@ const mocks = vi.hoisted(() => ({
         userRole: 'user',
         verifyAuth: vi.fn().mockResolvedValue(true),
     },
-    mockUnwrap: vi.fn((result: { data?: unknown; error?: unknown }) => {
-        if (result.error) throw result.error;
-        return result.data;
-    }),
-    mockUnwrapOr: vi.fn((result: { data?: unknown; error?: unknown }, fallback: unknown) => {
-        return result.error ? fallback : (result.data ?? fallback);
-    }),
-}));
-
-vi.mock('$lib/api', () => ({
-    getK8sResourceLimitsApiV1K8sLimitsGet: (...args: unknown[]) => mocks.getK8sResourceLimitsApiV1K8sLimitsGet(...args),
-    getExampleScriptsApiV1ExampleScriptsGet: (...args: unknown[]) =>
-        mocks.getExampleScriptsApiV1ExampleScriptsGet(...args),
-    listSavedScriptsApiV1ScriptsGet: (...args: unknown[]) => mocks.listSavedScriptsApiV1ScriptsGet(...args),
-    createSavedScriptApiV1ScriptsPost: (...args: unknown[]) => mocks.createSavedScriptApiV1ScriptsPost(...args),
-    updateSavedScriptApiV1ScriptsScriptIdPut: (...args: unknown[]) =>
-        mocks.updateSavedScriptApiV1ScriptsScriptIdPut(...args),
-    deleteSavedScriptApiV1ScriptsScriptIdDelete: (...args: unknown[]) =>
-        mocks.deleteSavedScriptApiV1ScriptsScriptIdDelete(...args),
 }));
 
 vi.mock('$stores/auth.svelte', () => ({ authStore: mocks.mockAuthStore }));
@@ -67,11 +53,6 @@ vi.mock('$stores/userSettings.svelte', () => ({
         settings: null,
         editorSettings: { font_size: 14, tab_size: 4, use_tabs: false, word_wrap: true, show_line_numbers: true },
     },
-}));
-
-vi.mock('$lib/api-interceptors', () => ({
-    unwrap: (...args: unknown[]) => (mocks.mockUnwrap as (...a: unknown[]) => unknown)(...args),
-    unwrapOr: (...args: unknown[]) => (mocks.mockUnwrapOr as (...a: unknown[]) => unknown)(...args),
 }));
 
 vi.mock('$lib/editor', () => ({ createExecutionState: () => mocks.mockExecutionState }));
@@ -106,10 +87,6 @@ describe('Editor', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         localStorage.clear();
-        vi.spyOn(toast, 'success');
-        vi.spyOn(toast, 'error');
-        vi.spyOn(toast, 'warning');
-        vi.spyOn(toast, 'info');
         vi.spyOn(meta, 'updateMetaTags');
         vi.stubGlobal('confirm', mocks.mockConfirm);
         mocks.mockAuthStore.isAuthenticated = true;
@@ -119,18 +96,12 @@ describe('Editor', () => {
         mocks.mockExecutionState.result = null;
         mocks.mockExecutionState.error = null;
 
-        mocks.getK8sResourceLimitsApiV1K8sLimitsGet.mockResolvedValue({
-            data: createMockLimits(),
-            error: undefined,
-        });
-        mocks.getExampleScriptsApiV1ExampleScriptsGet.mockResolvedValue({
-            data: { scripts: { python: '  print("Hello")' } },
-            error: undefined,
-        });
-        mocks.listSavedScriptsApiV1ScriptsGet.mockResolvedValue({ data: { scripts: [] }, error: undefined });
-        mocks.createSavedScriptApiV1ScriptsPost.mockResolvedValue({ data: { script_id: 'new-1' }, error: undefined });
-        mocks.updateSavedScriptApiV1ScriptsScriptIdPut.mockResolvedValue({ data: {}, error: undefined });
-        mocks.deleteSavedScriptApiV1ScriptsScriptIdDelete.mockResolvedValue({ data: {}, error: undefined });
+        mockApi(getK8sResourceLimitsApiV1K8sLimitsGet).ok(createMockLimits());
+        mockApi(getExampleScriptsApiV1ExampleScriptsGet).ok({ scripts: { python: '  print("Hello")' } });
+        mockApi(listSavedScriptsApiV1ScriptsGet).ok({ scripts: [] });
+        mockApi(createSavedScriptApiV1ScriptsPost).ok({ script_id: 'new-1' });
+        mockApi(updateSavedScriptApiV1ScriptsScriptIdPut).ok({});
+        mockApi(deleteSavedScriptApiV1ScriptsScriptIdDelete).ok({});
     });
 
     afterEach(() => vi.unstubAllGlobals());
@@ -144,15 +115,15 @@ describe('Editor', () => {
             await renderEditor();
             await waitFor(() => {
                 expect(mocks.mockAuthStore.verifyAuth).toHaveBeenCalled();
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
-                expect(mocks.getExampleScriptsApiV1ExampleScriptsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
+                expect(vi.mocked(getExampleScriptsApiV1ExampleScriptsGet)).toHaveBeenCalled();
             });
         });
 
         it('calls listSavedScripts when authenticated', async () => {
             await renderEditor();
             await waitFor(() => {
-                expect(mocks.listSavedScriptsApiV1ScriptsGet).toHaveBeenCalled();
+                expect(vi.mocked(listSavedScriptsApiV1ScriptsGet)).toHaveBeenCalled();
             });
         });
 
@@ -160,9 +131,9 @@ describe('Editor', () => {
             mocks.mockAuthStore.isAuthenticated = false;
             await renderEditor();
             await waitFor(() => {
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
-            expect(mocks.listSavedScriptsApiV1ScriptsGet).not.toHaveBeenCalled();
+            expect(vi.mocked(listSavedScriptsApiV1ScriptsGet)).not.toHaveBeenCalled();
         });
 
         it('renders page heading "Code Editor"', async () => {
@@ -188,7 +159,7 @@ describe('Editor', () => {
             mocks.mockAuthStore.isAuthenticated = false;
             await renderEditor();
             await waitFor(() => {
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
             await user.click(screen.getByRole('button', { name: 'Toggle Script Options' }));
             expect(screen.queryByTitle('Save current script')).not.toBeInTheDocument();
@@ -197,7 +168,7 @@ describe('Editor', () => {
         it('creates new script via POST API when Save is clicked', async () => {
             await renderEditor();
             await waitFor(() => {
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
 
             await user.type(screen.getByLabelText('Script Name'), 'My New Script');
@@ -205,7 +176,7 @@ describe('Editor', () => {
             await user.click(screen.getByTitle('Save current script'));
 
             await waitFor(() => {
-                expect(mocks.createSavedScriptApiV1ScriptsPost).toHaveBeenCalledWith({
+                expect(vi.mocked(createSavedScriptApiV1ScriptsPost)).toHaveBeenCalledWith({
                     body: expect.objectContaining({
                         name: 'My New Script',
                         lang: 'python',
@@ -217,33 +188,31 @@ describe('Editor', () => {
         });
 
         it('falls back to create when update returns 404', async () => {
-            mocks.listSavedScriptsApiV1ScriptsGet.mockResolvedValue({
-                data: {
-                    scripts: [
-                        {
-                            script_id: 'script-99',
-                            name: 'Existing Script',
-                            script: 'print(1)',
-                            lang: 'python',
-                            lang_version: '3.11',
-                        },
-                    ],
-                },
-                error: undefined,
+            mockApi(listSavedScriptsApiV1ScriptsGet).ok({
+                scripts: [
+                    {
+                        script_id: 'script-99',
+                        name: 'Existing Script',
+                        script: 'print(1)',
+                        lang: 'python',
+                        lang_version: '3.11',
+                        description: null,
+                        created_at: '2024-01-01T00:00:00Z',
+                        updated_at: '2024-01-01T00:00:00Z',
+                    },
+                ],
             });
-            mocks.updateSavedScriptApiV1ScriptsScriptIdPut.mockResolvedValue({
+            vi.mocked(updateSavedScriptApiV1ScriptsScriptIdPut).mockResolvedValue({
                 data: undefined,
                 error: { detail: 'Not found' },
-                response: { status: 404 },
-            });
-            mocks.createSavedScriptApiV1ScriptsPost.mockResolvedValue({
-                data: { script_id: 'fallback-1' },
-                error: undefined,
-            });
+                request: new Request('http://test'),
+                response: new Response(null, { status: 404 }),
+            } as any);
+            mockApi(createSavedScriptApiV1ScriptsPost).ok({ script_id: 'fallback-1' });
 
             await renderEditor();
             await waitFor(() => {
-                expect(mocks.listSavedScriptsApiV1ScriptsGet).toHaveBeenCalled();
+                expect(vi.mocked(listSavedScriptsApiV1ScriptsGet)).toHaveBeenCalled();
             });
 
             // Load saved script to set currentScriptId
@@ -260,7 +229,7 @@ describe('Editor', () => {
             await user.click(screen.getByTitle('Save current script'));
 
             await waitFor(() => {
-                expect(mocks.updateSavedScriptApiV1ScriptsScriptIdPut).toHaveBeenCalledWith({
+                expect(vi.mocked(updateSavedScriptApiV1ScriptsScriptIdPut)).toHaveBeenCalledWith({
                     path: { script_id: 'script-99' },
                     body: expect.objectContaining({
                         name: 'Existing Script',
@@ -270,7 +239,7 @@ describe('Editor', () => {
                 });
             });
             await waitFor(() => {
-                expect(mocks.createSavedScriptApiV1ScriptsPost).toHaveBeenCalledWith({
+                expect(vi.mocked(createSavedScriptApiV1ScriptsPost)).toHaveBeenCalledWith({
                     body: expect.objectContaining({
                         name: 'Existing Script',
                         lang: 'python',
@@ -285,24 +254,24 @@ describe('Editor', () => {
     describe('Delete script', () => {
         it('calls confirm and delete API when delete button is clicked', async () => {
             mocks.mockConfirm.mockReturnValue(true);
-            mocks.listSavedScriptsApiV1ScriptsGet.mockResolvedValue({
-                data: {
-                    scripts: [
-                        {
-                            script_id: 'script-99',
-                            name: 'My Script',
-                            script: 'print(1)',
-                            lang: 'python',
-                            lang_version: '3.11',
-                        },
-                    ],
-                },
-                error: undefined,
+            mockApi(listSavedScriptsApiV1ScriptsGet).ok({
+                scripts: [
+                    {
+                        script_id: 'script-99',
+                        name: 'My Script',
+                        script: 'print(1)',
+                        lang: 'python',
+                        lang_version: '3.11',
+                        description: null,
+                        created_at: '2024-01-01T00:00:00Z',
+                        updated_at: '2024-01-01T00:00:00Z',
+                    },
+                ],
             });
 
             await renderEditor();
             await waitFor(() => {
-                expect(mocks.listSavedScriptsApiV1ScriptsGet).toHaveBeenCalled();
+                expect(vi.mocked(listSavedScriptsApiV1ScriptsGet)).toHaveBeenCalled();
             });
 
             // Open options panel, then expand saved scripts list
@@ -315,7 +284,7 @@ describe('Editor', () => {
             await user.click(screen.getByTitle('Delete My Script'));
             expect(mocks.mockConfirm).toHaveBeenCalledWith('Are you sure you want to delete "My Script"?');
             await waitFor(() => {
-                expect(mocks.deleteSavedScriptApiV1ScriptsScriptIdDelete).toHaveBeenCalledWith({
+                expect(vi.mocked(deleteSavedScriptApiV1ScriptsScriptIdDelete)).toHaveBeenCalledWith({
                     path: { script_id: 'script-99' },
                 });
             });
@@ -327,7 +296,7 @@ describe('Editor', () => {
         it('calls execution.execute with script, lang, and version when Run Script is clicked', async () => {
             await renderEditor();
             await waitFor(() => {
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
 
             await user.click(screen.getByRole('button', { name: /Run Script/i }));
@@ -339,7 +308,7 @@ describe('Editor', () => {
         it('calls execution.reset and shows toast when New is clicked', async () => {
             await renderEditor();
             await waitFor(() => {
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
 
             // Open options panel then click New inside ScriptActions
@@ -364,7 +333,7 @@ describe('Editor', () => {
         it('rejects file > 1MB with error toast', async () => {
             const input = createFileInput();
             await waitFor(() => {
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
             const bigFile = new File(['x'.repeat(1024 * 1024 + 1)], 'large.py', { type: 'text/plain' });
             fireFileChange(input, bigFile);
@@ -374,7 +343,7 @@ describe('Editor', () => {
         it('rejects unsupported file extension with error toast', async () => {
             const input = createFileInput();
             await waitFor(() => {
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
             const badFile = new File(['content'], 'data.csv', { type: 'text/csv' });
             fireFileChange(input, badFile);
@@ -384,7 +353,7 @@ describe('Editor', () => {
         it('loads .py file content and shows info toast', async () => {
             const input = createFileInput();
             await waitFor(() => {
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
             const pyFile = new File(['print("loaded")'], 'test_script.py', { type: 'text/plain' });
             fireFileChange(input, pyFile);
@@ -400,7 +369,7 @@ describe('Editor', () => {
         it('loads example for selected language', async () => {
             await renderEditor();
             await waitFor(() => {
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
             const exampleBtn = screen.getByTitle('Load an example script for the selected language');
             await user.click(exampleBtn);
@@ -409,13 +378,10 @@ describe('Editor', () => {
         });
 
         it('shows warning when no example available', async () => {
-            mocks.getExampleScriptsApiV1ExampleScriptsGet.mockResolvedValue({
-                data: { scripts: {} },
-                error: undefined,
-            });
+            mockApi(getExampleScriptsApiV1ExampleScriptsGet).ok({ scripts: {} });
             await renderEditor();
             await waitFor(() => {
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
             const exampleBtn = screen.getByTitle('Load an example script for the selected language');
             await user.click(exampleBtn);
@@ -427,7 +393,7 @@ describe('Editor', () => {
         it('creates download with correct filename and extension', async () => {
             await renderEditor();
             await waitFor(() => {
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
 
             // Spy on anchor creation without replacing createElement entirely
@@ -460,7 +426,7 @@ describe('Editor', () => {
         it('saves script name to localStorage after changes', async () => {
             await renderEditor();
             await waitFor(() => {
-                expect(mocks.getK8sResourceLimitsApiV1K8sLimitsGet).toHaveBeenCalled();
+                expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
 
             await user.type(screen.getByLabelText('Script Name'), 'Persisted');

--- a/frontend/src/routes/__tests__/Editor.test.ts
+++ b/frontend/src/routes/__tests__/Editor.test.ts
@@ -215,7 +215,6 @@ describe('Editor', () => {
                 expect(vi.mocked(listSavedScriptsApiV1ScriptsGet)).toHaveBeenCalled();
             });
 
-            // Load saved script to set currentScriptId
             await user.click(screen.getByRole('button', { name: 'Toggle Script Options' }));
             await user.click(screen.getByRole('button', { name: 'Show Saved Scripts' }));
             await waitFor(() => {
@@ -224,7 +223,6 @@ describe('Editor', () => {
             await user.click(screen.getByTitle(/Load Existing Script/));
             expect(toast.info).toHaveBeenCalledWith('Loaded script: Existing Script');
 
-            // Options closed after loadScript, reopen and click Save
             await user.click(screen.getByRole('button', { name: 'Toggle Script Options' }));
             await user.click(screen.getByTitle('Save current script'));
 
@@ -274,7 +272,6 @@ describe('Editor', () => {
                 expect(vi.mocked(listSavedScriptsApiV1ScriptsGet)).toHaveBeenCalled();
             });
 
-            // Open options panel, then expand saved scripts list
             await user.click(screen.getByRole('button', { name: 'Toggle Script Options' }));
             await user.click(screen.getByRole('button', { name: 'Show Saved Scripts' }));
             await waitFor(() => {
@@ -311,7 +308,6 @@ describe('Editor', () => {
                 expect(vi.mocked(getK8sResourceLimitsApiV1K8sLimitsGet)).toHaveBeenCalled();
             });
 
-            // Open options panel then click New inside ScriptActions
             await user.click(screen.getByRole('button', { name: 'Toggle Script Options' }));
             await user.click(screen.getByRole('button', { name: 'New' }));
             expect(mocks.mockExecutionState.reset).toHaveBeenCalled();

--- a/frontend/src/routes/__tests__/Home.test.ts
+++ b/frontend/src/routes/__tests__/Home.test.ts
@@ -3,8 +3,6 @@ import { render, screen, waitFor } from '@testing-library/svelte';
 import * as meta from '$utils/meta';
 import Home from '$routes/Home.svelte';
 
-vi.mock('@mateothegreat/svelte5-router', () => ({ route: () => {}, goto: vi.fn() }));
-
 describe('Home', () => {
     beforeEach(() => {
         vi.clearAllMocks();

--- a/frontend/src/routes/__tests__/Login.test.ts
+++ b/frontend/src/routes/__tests__/Login.test.ts
@@ -6,10 +6,11 @@ import * as router from '@mateothegreat/svelte5-router';
 import * as meta from '$utils/meta';
 import Login from '$routes/Login.svelte';
 
+import { getErrorMessage } from '$lib/api-interceptors';
+
 const mocks = vi.hoisted(() => ({
     mockLogin: vi.fn(),
     mockLoadUserSettings: vi.fn(),
-    mockGetErrorMessage: vi.fn((err: unknown, fallback?: string) => fallback || String(err)),
     mockAuthStore: {
         login: vi.fn(),
         isAuthenticated: false,
@@ -25,21 +26,11 @@ vi.mock('$lib/user-settings', () => ({
     loadUserSettings: mocks.mockLoadUserSettings,
 }));
 
-vi.mock('$lib/api-interceptors', () => ({
-    getErrorMessage: mocks.mockGetErrorMessage,
-}));
-
-vi.mock('@mateothegreat/svelte5-router', () => ({ route: () => {}, goto: vi.fn() }));
-
 describe('Login', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mocks.mockAuthStore.login = vi.fn().mockResolvedValue(true);
         mocks.mockLoadUserSettings.mockResolvedValue(undefined);
-        vi.spyOn(toast, 'success');
-        vi.spyOn(toast, 'error');
-        vi.spyOn(toast, 'warning');
-        vi.spyOn(toast, 'info');
         vi.spyOn(meta, 'updateMetaTags');
     });
 
@@ -101,7 +92,7 @@ describe('Login', () => {
 
     it('shows error message in DOM on login failure (no duplicate toast)', async () => {
         mocks.mockAuthStore.login = vi.fn().mockRejectedValue(new Error('Invalid credentials'));
-        mocks.mockGetErrorMessage.mockReturnValue('Login failed. Please check your credentials.');
+        vi.mocked(getErrorMessage).mockReturnValue('Login failed. Please check your credentials.');
 
         await renderLogin();
         await user.type(screen.getByPlaceholderText('Username'), 'bad');

--- a/frontend/src/routes/__tests__/Notifications.test.ts
+++ b/frontend/src/routes/__tests__/Notifications.test.ts
@@ -19,8 +19,6 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('$stores/notificationStore.svelte', () => ({ notificationStore: mocks.mockNotificationStore }));
 
-vi.mock('$lib/api', () => ({}));
-
 describe('Notifications', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -28,8 +26,6 @@ describe('Notifications', () => {
         mocks.mockNotificationStore.unreadCount = 0;
         mocks.mockNotificationStore.loading = false;
         mocks.mockNotificationStore.load.mockResolvedValue([]);
-        vi.spyOn(toast, 'success');
-        vi.spyOn(toast, 'error');
         mocks.mockNotificationStore.markAsRead.mockResolvedValue(true);
         mocks.mockNotificationStore.markAllAsRead.mockResolvedValue(true);
         mocks.mockNotificationStore.delete.mockResolvedValue(true);

--- a/frontend/src/routes/__tests__/Register.test.ts
+++ b/frontend/src/routes/__tests__/Register.test.ts
@@ -1,34 +1,18 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
-import { user } from '$test/test-utils';
+import { user, mockApi } from '$test/test-utils';
 import { toast } from 'svelte-sonner';
 import * as router from '@mateothegreat/svelte5-router';
 import * as meta from '$utils/meta';
 import Register from '$routes/Register.svelte';
 
-const mocks = vi.hoisted(() => ({
-    registerApiV1AuthRegisterPost: vi.fn(),
-    mockGetErrorMessage: vi.fn((_err: unknown, fallback?: string) => fallback || 'Unknown error'),
-}));
-
-vi.mock('$lib/api', () => ({
-    registerApiV1AuthRegisterPost: mocks.registerApiV1AuthRegisterPost,
-}));
-
-vi.mock('$lib/api-interceptors', () => ({
-    getErrorMessage: mocks.mockGetErrorMessage,
-}));
-
-vi.mock('@mateothegreat/svelte5-router', () => ({ route: () => {}, goto: vi.fn() }));
+import { registerApiV1AuthRegisterPost } from '$lib/api';
+import { getErrorMessage } from '$lib/api-interceptors';
 
 describe('Register', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        mocks.registerApiV1AuthRegisterPost.mockResolvedValue({ data: {}, error: undefined });
-        vi.spyOn(toast, 'success');
-        vi.spyOn(toast, 'error');
-        vi.spyOn(toast, 'warning');
-        vi.spyOn(toast, 'info');
+        mockApi(registerApiV1AuthRegisterPost).ok({});
         vi.spyOn(meta, 'updateMetaTags');
     });
 
@@ -77,7 +61,7 @@ describe('Register', () => {
             expect(screen.getByText(expectedError)).toBeInTheDocument();
         });
         expect(toast[toastType as keyof typeof toast]).toHaveBeenCalledWith(expectedError);
-        expect(mocks.registerApiV1AuthRegisterPost).not.toHaveBeenCalled();
+        expect(vi.mocked(registerApiV1AuthRegisterPost)).not.toHaveBeenCalled();
     });
 
     it('calls API with correct payload, shows toast, and redirects on success', async () => {
@@ -89,7 +73,7 @@ describe('Register', () => {
         await user.click(screen.getByRole('button', { name: /create account/i }));
 
         await waitFor(() => {
-            expect(mocks.registerApiV1AuthRegisterPost).toHaveBeenCalledWith({
+            expect(vi.mocked(registerApiV1AuthRegisterPost)).toHaveBeenCalledWith({
                 body: { username: 'newuser', email: 'new@email.com', password: 'securepass' },
             });
         });
@@ -98,11 +82,8 @@ describe('Register', () => {
     });
 
     it('shows error in DOM on API error (no duplicate toast)', async () => {
-        mocks.registerApiV1AuthRegisterPost.mockResolvedValue({
-            data: undefined,
-            error: { detail: 'Username taken' },
-        });
-        mocks.mockGetErrorMessage.mockReturnValue('Registration failed. Please try again.');
+        mockApi(registerApiV1AuthRegisterPost).err({ detail: 'Username taken' });
+        vi.mocked(getErrorMessage).mockReturnValue('Registration failed. Please try again.');
 
         await renderRegister();
         await user.type(screen.getByPlaceholderText('Username'), 'taken');
@@ -119,7 +100,7 @@ describe('Register', () => {
 
     it('disables button and shows "Registering..." during loading', async () => {
         let resolveRegister: (v: unknown) => void;
-        mocks.registerApiV1AuthRegisterPost.mockImplementation(
+        mockApi(registerApiV1AuthRegisterPost).mock.mockImplementation(
             () =>
                 new Promise((r) => {
                     resolveRegister = r;

--- a/frontend/src/routes/__tests__/Settings.test.ts
+++ b/frontend/src/routes/__tests__/Settings.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
-import { user } from '$test/test-utils';
+import { user, mockApi } from '$test/test-utils';
 import { toast } from 'svelte-sonner';
 import Settings from '$routes/Settings.svelte';
 
 function createMockSettings() {
     return {
+        user_id: 'user-1',
         theme: 'dark',
+        timezone: 'UTC',
+        date_format: 'YYYY-MM-DD',
+        time_format: '24h',
         notifications: {
             execution_completed: true,
             execution_failed: false,
@@ -21,14 +25,19 @@ function createMockSettings() {
             word_wrap: false,
             show_line_numbers: true,
         },
+        custom_settings: {},
+        version: 1,
     };
 }
 
+import {
+    getUserSettingsApiV1UserSettingsGet,
+    updateUserSettingsApiV1UserSettingsPut,
+    restoreSettingsApiV1UserSettingsRestorePost,
+    getSettingsHistoryApiV1UserSettingsHistoryGet,
+} from '$lib/api';
+
 const mocks = vi.hoisted(() => ({
-    getUserSettingsApiV1UserSettingsGet: vi.fn(),
-    updateUserSettingsApiV1UserSettingsPut: vi.fn(),
-    restoreSettingsApiV1UserSettingsRestorePost: vi.fn(),
-    getSettingsHistoryApiV1UserSettingsHistoryGet: vi.fn(),
     mockSetTheme: vi.fn(),
     mockSetUserSettings: vi.fn(),
     mockConfirm: vi.fn(),
@@ -38,16 +47,6 @@ const mocks = vi.hoisted(() => ({
         userRole: 'user',
         verifyAuth: vi.fn(),
     },
-}));
-
-vi.mock('$lib/api', () => ({
-    getUserSettingsApiV1UserSettingsGet: (...args: unknown[]) => mocks.getUserSettingsApiV1UserSettingsGet(...args),
-    updateUserSettingsApiV1UserSettingsPut: (...args: unknown[]) =>
-        mocks.updateUserSettingsApiV1UserSettingsPut(...args),
-    restoreSettingsApiV1UserSettingsRestorePost: (...args: unknown[]) =>
-        mocks.restoreSettingsApiV1UserSettingsRestorePost(...args),
-    getSettingsHistoryApiV1UserSettingsHistoryGet: (...args: unknown[]) =>
-        mocks.getSettingsHistoryApiV1UserSettingsHistoryGet(...args),
 }));
 
 vi.mock('$stores/auth.svelte', () => ({ authStore: mocks.mockAuthStore }));
@@ -60,20 +59,10 @@ vi.mock('$stores/userSettings.svelte', () => ({
 describe('Settings', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        vi.spyOn(toast, 'success');
-        vi.spyOn(toast, 'error');
-        vi.spyOn(toast, 'warning');
-        vi.spyOn(toast, 'info');
         vi.stubGlobal('confirm', mocks.mockConfirm);
         mocks.mockAuthStore.isAuthenticated = true;
-        mocks.getUserSettingsApiV1UserSettingsGet.mockResolvedValue({
-            data: createMockSettings(),
-            error: undefined,
-        });
-        mocks.updateUserSettingsApiV1UserSettingsPut.mockResolvedValue({
-            data: createMockSettings(),
-            error: undefined,
-        });
+        mockApi(getUserSettingsApiV1UserSettingsGet).ok(createMockSettings());
+        mockApi(updateUserSettingsApiV1UserSettingsPut).ok(createMockSettings());
     });
 
     afterEach(() => vi.unstubAllGlobals());
@@ -86,7 +75,7 @@ describe('Settings', () => {
         it('calls API on mount and populates form', async () => {
             await renderSettings();
             await waitFor(() => {
-                expect(mocks.getUserSettingsApiV1UserSettingsGet).toHaveBeenCalled();
+                expect(vi.mocked(getUserSettingsApiV1UserSettingsGet)).toHaveBeenCalled();
             });
             await waitFor(() => {
                 expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
@@ -96,7 +85,7 @@ describe('Settings', () => {
         it('does not call API when unauthenticated', async () => {
             mocks.mockAuthStore.isAuthenticated = false;
             await renderSettings();
-            expect(mocks.getUserSettingsApiV1UserSettingsGet).not.toHaveBeenCalled();
+            expect(vi.mocked(getUserSettingsApiV1UserSettingsGet)).not.toHaveBeenCalled();
         });
     });
 
@@ -119,10 +108,7 @@ describe('Settings', () => {
 
     describe('Theme dropdown', () => {
         it('selects "Dark" and calls setTheme with "dark"', async () => {
-            mocks.getUserSettingsApiV1UserSettingsGet.mockResolvedValue({
-                data: { ...createMockSettings(), theme: 'light' },
-                error: undefined,
-            });
+            mockApi(getUserSettingsApiV1UserSettingsGet).ok({ ...createMockSettings(), theme: 'light' });
             await renderSettings();
             await waitFor(() => {
                 expect(screen.getByText('General Settings')).toBeInTheDocument();
@@ -150,16 +136,13 @@ describe('Settings', () => {
             await waitFor(() => {
                 expect(toast.info).toHaveBeenCalledWith('No changes to save');
             });
-            expect(mocks.updateUserSettingsApiV1UserSettingsPut).not.toHaveBeenCalled();
+            expect(vi.mocked(updateUserSettingsApiV1UserSettingsPut)).not.toHaveBeenCalled();
         });
 
         it('saves changed editor settings and shows success toast', async () => {
             const settings = createMockSettings();
             const updatedSettings = { ...settings, editor: { ...settings.editor, font_size: 18 } };
-            mocks.updateUserSettingsApiV1UserSettingsPut.mockResolvedValue({
-                data: updatedSettings,
-                error: undefined,
-            });
+            mockApi(updateUserSettingsApiV1UserSettingsPut).ok(updatedSettings);
 
             await renderSettings();
             await waitFor(() => {
@@ -177,9 +160,9 @@ describe('Settings', () => {
 
             await user.click(screen.getByRole('button', { name: /save settings/i }));
             await waitFor(() => {
-                expect(mocks.updateUserSettingsApiV1UserSettingsPut).toHaveBeenCalled();
+                expect(vi.mocked(updateUserSettingsApiV1UserSettingsPut)).toHaveBeenCalled();
             });
-            const callArgs = mocks.updateUserSettingsApiV1UserSettingsPut.mock.calls[0]![0];
+            const callArgs = vi.mocked(updateUserSettingsApiV1UserSettingsPut).mock.calls[0]![0];
             expect(callArgs.body).toHaveProperty('editor');
             await waitFor(() => {
                 expect(toast.success).toHaveBeenCalledWith('Settings saved successfully');
@@ -190,13 +173,18 @@ describe('Settings', () => {
 
     describe('History', () => {
         it('opens history modal and calls API', async () => {
-            mocks.getSettingsHistoryApiV1UserSettingsHistoryGet.mockResolvedValue({
-                data: {
-                    history: [
-                        { timestamp: '2025-01-15T10:00:00Z', field: 'theme', old_value: 'light', new_value: 'dark' },
-                    ],
-                },
-                error: undefined,
+            mockApi(getSettingsHistoryApiV1UserSettingsHistoryGet).ok({
+                history: [
+                    {
+                        timestamp: '2025-01-15T10:00:00Z',
+                        event_type: 'settings_updated',
+                        field: 'theme',
+                        old_value: 'light',
+                        new_value: 'dark',
+                        reason: null,
+                    },
+                ],
+                limit: 10,
             });
 
             await renderSettings();
@@ -208,16 +196,13 @@ describe('Settings', () => {
             await waitFor(() => {
                 expect(screen.getByRole('heading', { name: 'Settings History' })).toBeInTheDocument();
             });
-            expect(mocks.getSettingsHistoryApiV1UserSettingsHistoryGet).toHaveBeenCalledWith({
+            expect(vi.mocked(getSettingsHistoryApiV1UserSettingsHistoryGet)).toHaveBeenCalledWith({
                 query: { limit: 10 },
             });
         });
 
         it('uses cache on second open within 30s', async () => {
-            mocks.getSettingsHistoryApiV1UserSettingsHistoryGet.mockResolvedValue({
-                data: { history: [] },
-                error: undefined,
-            });
+            mockApi(getSettingsHistoryApiV1UserSettingsHistoryGet).ok({ history: [], limit: 10 });
 
             await renderSettings();
             await waitFor(() => {
@@ -226,36 +211,32 @@ describe('Settings', () => {
 
             await user.click(screen.getByRole('button', { name: /view history/i }));
             await waitFor(() => {
-                expect(mocks.getSettingsHistoryApiV1UserSettingsHistoryGet).toHaveBeenCalledTimes(1);
+                expect(vi.mocked(getSettingsHistoryApiV1UserSettingsHistoryGet)).toHaveBeenCalledTimes(1);
             });
 
             await user.click(screen.getByRole('button', { name: 'Close' }));
             await user.click(screen.getByRole('button', { name: /view history/i }));
-            expect(mocks.getSettingsHistoryApiV1UserSettingsHistoryGet).toHaveBeenCalledTimes(1);
+            expect(vi.mocked(getSettingsHistoryApiV1UserSettingsHistoryGet)).toHaveBeenCalledTimes(1);
         });
     });
 
     describe('Restore', () => {
         const historyEntry = {
             timestamp: '2025-01-15T10:00:00Z',
+            event_type: 'settings_updated' as const,
             field: 'theme',
             old_value: 'light',
             new_value: 'dark',
+            reason: null,
         };
 
         function setupHistoryMock() {
-            mocks.getSettingsHistoryApiV1UserSettingsHistoryGet.mockResolvedValue({
-                data: { history: [historyEntry] },
-                error: undefined,
-            });
+            mockApi(getSettingsHistoryApiV1UserSettingsHistoryGet).ok({ history: [historyEntry], limit: 10 });
         }
 
         it('restores settings on confirm', async () => {
             mocks.mockConfirm.mockReturnValue(true);
-            mocks.restoreSettingsApiV1UserSettingsRestorePost.mockResolvedValue({
-                data: { ...createMockSettings(), theme: 'light' },
-                error: undefined,
-            });
+            mockApi(restoreSettingsApiV1UserSettingsRestorePost).ok({ ...createMockSettings(), theme: 'light' });
             setupHistoryMock();
 
             await renderSettings();
@@ -270,7 +251,7 @@ describe('Settings', () => {
 
             await user.click(screen.getByRole('button', { name: 'Restore' }));
             await waitFor(() => {
-                expect(mocks.restoreSettingsApiV1UserSettingsRestorePost).toHaveBeenCalledWith({
+                expect(vi.mocked(restoreSettingsApiV1UserSettingsRestorePost)).toHaveBeenCalledWith({
                     body: { timestamp: '2025-01-15T10:00:00Z', reason: 'User requested restore' },
                 });
             });
@@ -293,7 +274,7 @@ describe('Settings', () => {
             });
 
             await user.click(screen.getByRole('button', { name: 'Restore' }));
-            expect(mocks.restoreSettingsApiV1UserSettingsRestorePost).not.toHaveBeenCalled();
+            expect(vi.mocked(restoreSettingsApiV1UserSettingsRestorePost)).not.toHaveBeenCalled();
         });
     });
 });

--- a/frontend/src/routes/admin/AdminExecutions.svelte
+++ b/frontend/src/routes/admin/AdminExecutions.svelte
@@ -211,11 +211,13 @@
                             currentPage={store.pagination.currentPage}
                             {totalPages}
                             totalItems={store.total}
-                            pageSize={store.pagination.pageSize}
+                            bind:pageSize={store.pagination.pageSize}
                             onPageChange={(page) =>
                                 store.pagination.handlePageChange(page, () => store.loadExecutions())}
-                            onPageSizeChange={(size) =>
-                                store.pagination.handlePageSizeChange(size, () => store.loadExecutions())}
+                            onPageSizeChange={() => {
+                                store.pagination.currentPage = 1;
+                                store.loadExecutions();
+                            }}
                             pageSizeOptions={[10, 20, 50, 100]}
                             itemName="executions"
                         />

--- a/frontend/src/routes/admin/AdminSagas.svelte
+++ b/frontend/src/routes/admin/AdminSagas.svelte
@@ -37,8 +37,9 @@
         store.pagination.handlePageChange(page, () => store.loadSagas());
     }
 
-    function handlePageSizeChange(size: number): void {
-        store.pagination.handlePageSizeChange(size, () => store.loadSagas());
+    function handlePageSizeChange(): void {
+        store.pagination.currentPage = 1;
+        store.loadSagas();
     }
 
     let prevStateFilter = $state(store.stateFilter);
@@ -101,7 +102,7 @@
                     currentPage={store.pagination.currentPage}
                     {totalPages}
                     totalItems={store.totalItems}
-                    pageSize={store.pagination.pageSize}
+                    bind:pageSize={store.pagination.pageSize}
                     onPageChange={handlePageChange}
                     onPageSizeChange={handlePageSizeChange}
                     itemName="sagas"

--- a/frontend/src/routes/admin/AdminUsers.svelte
+++ b/frontend/src/routes/admin/AdminUsers.svelte
@@ -254,8 +254,7 @@
     function handlePageChange(page: number): void {
         currentPage = page;
     }
-    function handlePageSizeChange(size: number): void {
-        pageSize = size;
+    function handlePageSizeChange(): void {
         currentPage = 1;
     }
 
@@ -340,7 +339,7 @@
                             {currentPage}
                             {totalPages}
                             totalItems={filteredUsers.length}
-                            {pageSize}
+                            bind:pageSize
                             onPageChange={handlePageChange}
                             onPageSizeChange={handlePageSizeChange}
                             pageSizeOptions={[5, 10, 20, 50]}

--- a/frontend/src/routes/admin/__tests__/AdminEvents.test.ts
+++ b/frontend/src/routes/admin/__tests__/AdminEvents.test.ts
@@ -9,6 +9,7 @@ import {
     createMockEventDetail,
     createMockUserOverview,
     user,
+    selectOption,
 } from '$test/test-utils';
 
 // Hoisted mocks
@@ -330,7 +331,7 @@ describe('AdminEvents', () => {
             const pageSizeSelect = await waitFor(() => screen.getByLabelText(/Show:/i));
 
             mocks.browseEventsApiV1AdminEventsBrowsePost.mockClear();
-            await user.selectOptions(pageSizeSelect, '25');
+            selectOption(pageSizeSelect, '25');
 
             await waitFor(() => {
                 expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalledWith(

--- a/frontend/src/routes/admin/__tests__/AdminEvents.test.ts
+++ b/frontend/src/routes/admin/__tests__/AdminEvents.test.ts
@@ -10,52 +10,25 @@ import {
     createMockUserOverview,
     user,
     selectOption,
+    mockApi,
 } from '$test/test-utils';
+import {
+    browseEventsApiV1AdminEventsBrowsePost,
+    getEventStatsApiV1AdminEventsStatsGet,
+    getEventDetailApiV1AdminEventsEventIdGet,
+    streamReplayStatusApiV1AdminEventsReplaySessionIdStatusGet,
+    replayEventsApiV1AdminEventsReplayPost,
+    deleteEventApiV1AdminEventsEventIdDelete,
+    getUserOverviewApiV1AdminUsersUserIdOverviewGet,
+} from '$lib/api';
+import { toast } from 'svelte-sonner';
 
-// Hoisted mocks
 const mocks = vi.hoisted(() => ({
-    browseEventsApiV1AdminEventsBrowsePost: vi.fn(),
-    getEventStatsApiV1AdminEventsStatsGet: vi.fn(),
-    getEventDetailApiV1AdminEventsEventIdGet: vi.fn(),
-    getReplayStatusApiV1AdminEventsReplaySessionIdStatusGet: vi.fn(),
-    replayEventsApiV1AdminEventsReplayPost: vi.fn(),
-    deleteEventApiV1AdminEventsEventIdDelete: vi.fn(),
-    getUserOverviewApiV1AdminUsersUserIdOverviewGet: vi.fn(),
-    addToast: vi.fn(),
     windowOpen: vi.fn(),
     windowConfirm: vi.fn(),
 }));
 
-// Mock API module
-vi.mock('../../../lib/api', () => ({
-    browseEventsApiV1AdminEventsBrowsePost: (...args: unknown[]) =>
-        mocks.browseEventsApiV1AdminEventsBrowsePost(...args),
-    getEventStatsApiV1AdminEventsStatsGet: (...args: unknown[]) => mocks.getEventStatsApiV1AdminEventsStatsGet(...args),
-    getEventDetailApiV1AdminEventsEventIdGet: (...args: unknown[]) =>
-        mocks.getEventDetailApiV1AdminEventsEventIdGet(...args),
-    getReplayStatusApiV1AdminEventsReplaySessionIdStatusGet: (...args: unknown[]) =>
-        mocks.getReplayStatusApiV1AdminEventsReplaySessionIdStatusGet(...args),
-    replayEventsApiV1AdminEventsReplayPost: (...args: unknown[]) =>
-        mocks.replayEventsApiV1AdminEventsReplayPost(...args),
-    deleteEventApiV1AdminEventsEventIdDelete: (...args: unknown[]) =>
-        mocks.deleteEventApiV1AdminEventsEventIdDelete(...args),
-    getUserOverviewApiV1AdminUsersUserIdOverviewGet: (...args: unknown[]) =>
-        mocks.getUserOverviewApiV1AdminUsersUserIdOverviewGet(...args),
-}));
-
-vi.mock('svelte-sonner', () => ({
-    toast: {
-        success: (...args: unknown[]) => mocks.addToast(...args),
-        error: (...args: unknown[]) => mocks.addToast(...args),
-        warning: (...args: unknown[]) => mocks.addToast(...args),
-        info: (...args: unknown[]) => mocks.addToast(...args),
-    },
-}));
-
-vi.mock('../../../lib/api-interceptors');
-
-// Simple mock for AdminLayout
-vi.mock('../AdminLayout.svelte', async () => {
+vi.mock('$routes/admin/AdminLayout.svelte', async () => {
     const { default: MockLayout } = await import('$routes/admin/__tests__/mocks/MockAdminLayout.svelte');
     return { default: MockLayout };
 });
@@ -63,14 +36,11 @@ vi.mock('../AdminLayout.svelte', async () => {
 import AdminEvents from '$routes/admin/AdminEvents.svelte';
 
 async function renderWithEvents(events = createMockEvents(5), stats = createMockStats()) {
-    mocks.browseEventsApiV1AdminEventsBrowsePost.mockResolvedValue({
-        data: { events, total: events.length },
-        error: null,
-    });
-    mocks.getEventStatsApiV1AdminEventsStatsGet.mockResolvedValue({ data: stats, error: null });
+    mockApi(browseEventsApiV1AdminEventsBrowsePost).ok({ events, total: events.length, skip: 0, limit: 10 });
+    mockApi(getEventStatsApiV1AdminEventsStatsGet).ok(stats);
 
     const result = render(AdminEvents);
-    await waitFor(() => expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalled());
+    await waitFor(() => expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalled());
     return result;
 }
 
@@ -79,17 +49,14 @@ describe('AdminEvents', () => {
         vi.unstubAllGlobals();
         mockWindowGlobals(mocks.windowOpen, mocks.windowConfirm);
         vi.clearAllMocks();
-        mocks.browseEventsApiV1AdminEventsBrowsePost.mockResolvedValue({ data: { events: [], total: 0 }, error: null });
-        mocks.getEventStatsApiV1AdminEventsStatsGet.mockResolvedValue({ data: null, error: null });
-        mocks.getReplayStatusApiV1AdminEventsReplaySessionIdStatusGet.mockResolvedValue({
-            data: {
-                session_id: 'test',
-                status: 'completed',
-                total_events: 0,
-                replayed_events: 0,
-                progress_percentage: 100,
-            },
-            error: null,
+        mockApi(browseEventsApiV1AdminEventsBrowsePost).ok({ events: [], total: 0, skip: 0, limit: 10 });
+        mockApi(getEventStatsApiV1AdminEventsStatsGet).ok(null);
+        mockApi(streamReplayStatusApiV1AdminEventsReplaySessionIdStatusGet).ok({
+            session_id: 'test',
+            status: 'completed',
+            total_events: 0,
+            replayed_events: 0,
+            progress_percentage: 100,
         });
         mocks.windowConfirm.mockReturnValue(true);
     });
@@ -98,8 +65,8 @@ describe('AdminEvents', () => {
         it('calls loadEvents and loadStats on mount', async () => {
             render(AdminEvents);
             await waitFor(() => {
-                expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalledTimes(1);
-                expect(mocks.getEventStatsApiV1AdminEventsStatsGet).toHaveBeenCalledTimes(1);
+                expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalledTimes(1);
+                expect(vi.mocked(getEventStatsApiV1AdminEventsStatsGet)).toHaveBeenCalledTimes(1);
             });
         });
 
@@ -111,19 +78,19 @@ describe('AdminEvents', () => {
             await vi.advanceTimersByTimeAsync(30000);
 
             await waitFor(() => {
-                expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalledTimes(2);
-                expect(mocks.getEventStatsApiV1AdminEventsStatsGet).toHaveBeenCalledTimes(2);
+                expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalledTimes(2);
+                expect(vi.mocked(getEventStatsApiV1AdminEventsStatsGet)).toHaveBeenCalledTimes(2);
             });
         });
 
         it('handles API error on load events and shows toast', async () => {
             const error = { message: 'Network error' };
-            mocks.browseEventsApiV1AdminEventsBrowsePost.mockImplementation(async () => {
-                mocks.addToast('Failed to load events');
-                return { data: null, error };
+            vi.mocked(browseEventsApiV1AdminEventsBrowsePost).mockImplementation(async () => {
+                toast.error('Failed to load events');
+                return { data: null, error } as any;
             });
             render(AdminEvents);
-            await waitFor(() => expect(mocks.addToast).toHaveBeenCalledWith('Failed to load events'));
+            await waitFor(() => expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to load events'));
         });
 
         it('displays empty state when no events', async () => {
@@ -191,12 +158,12 @@ describe('AdminEvents', () => {
     describe('refresh functionality', () => {
         it('refresh button reloads events', async () => {
             await renderWithEvents();
-            mocks.browseEventsApiV1AdminEventsBrowsePost.mockClear();
+            vi.mocked(browseEventsApiV1AdminEventsBrowsePost).mockClear();
 
             const refreshBtn = screen.getByRole('button', { name: /Refresh/i });
             await user.click(refreshBtn);
 
-            await waitFor(() => expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalled());
+            await waitFor(() => expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalled());
         });
     });
 
@@ -235,12 +202,12 @@ describe('AdminEvents', () => {
             await waitFor(() => expect(screen.getByLabelText(/Search/i)).toBeInTheDocument());
 
             await user.type(screen.getByLabelText(/Search/i), 'test query');
-            mocks.browseEventsApiV1AdminEventsBrowsePost.mockClear();
+            vi.mocked(browseEventsApiV1AdminEventsBrowsePost).mockClear();
 
             await user.click(screen.getByRole('button', { name: /^Apply$/i }));
 
             await waitFor(() => {
-                expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalledWith(
+                expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         body: expect.objectContaining({
                             filters: expect.objectContaining({
@@ -286,31 +253,35 @@ describe('AdminEvents', () => {
     describe('pagination', () => {
         it('shows pagination info', async () => {
             const events = createMockEvents(25);
-            mocks.browseEventsApiV1AdminEventsBrowsePost.mockResolvedValue({
-                data: { events: events.slice(0, 10), total: 25 },
-                error: null,
+            mockApi(browseEventsApiV1AdminEventsBrowsePost).ok({
+                events: events.slice(0, 10),
+                total: 25,
+                skip: 0,
+                limit: 10,
             });
-            mocks.getEventStatsApiV1AdminEventsStatsGet.mockResolvedValue({ data: createMockStats(), error: null });
+            mockApi(getEventStatsApiV1AdminEventsStatsGet).ok(createMockStats());
 
             render(AdminEvents);
             await waitFor(() => expect(screen.getByText(/Showing 1 to 10 of 25 events/i)).toBeInTheDocument());
         });
 
         it('changes page when next is clicked', async () => {
-            mocks.browseEventsApiV1AdminEventsBrowsePost.mockResolvedValue({
-                data: { events: createMockEvents(10), total: 25 },
-                error: null,
+            mockApi(browseEventsApiV1AdminEventsBrowsePost).ok({
+                events: createMockEvents(10),
+                total: 25,
+                skip: 0,
+                limit: 10,
             });
-            mocks.getEventStatsApiV1AdminEventsStatsGet.mockResolvedValue({ data: createMockStats(), error: null });
+            mockApi(getEventStatsApiV1AdminEventsStatsGet).ok(createMockStats());
 
             render(AdminEvents);
             const nextBtn = await waitFor(() => screen.getByTitle('Next page'));
 
-            mocks.browseEventsApiV1AdminEventsBrowsePost.mockClear();
+            vi.mocked(browseEventsApiV1AdminEventsBrowsePost).mockClear();
             await user.click(nextBtn);
 
             await waitFor(() => {
-                expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalledWith(
+                expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         body: expect.objectContaining({
                             skip: 10,
@@ -321,20 +292,22 @@ describe('AdminEvents', () => {
         });
 
         it('changes page size', async () => {
-            mocks.browseEventsApiV1AdminEventsBrowsePost.mockResolvedValue({
-                data: { events: createMockEvents(10), total: 50 },
-                error: null,
+            mockApi(browseEventsApiV1AdminEventsBrowsePost).ok({
+                events: createMockEvents(10),
+                total: 50,
+                skip: 0,
+                limit: 10,
             });
-            mocks.getEventStatsApiV1AdminEventsStatsGet.mockResolvedValue({ data: createMockStats(), error: null });
+            mockApi(getEventStatsApiV1AdminEventsStatsGet).ok(createMockStats());
 
             render(AdminEvents);
             const pageSizeSelect = await waitFor(() => screen.getByLabelText(/Show:/i));
 
-            mocks.browseEventsApiV1AdminEventsBrowsePost.mockClear();
+            vi.mocked(browseEventsApiV1AdminEventsBrowsePost).mockClear();
             selectOption(pageSizeSelect, '25');
 
             await waitFor(() => {
-                expect(mocks.browseEventsApiV1AdminEventsBrowsePost).toHaveBeenCalledWith(
+                expect(vi.mocked(browseEventsApiV1AdminEventsBrowsePost)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         body: expect.objectContaining({
                             limit: 25,
@@ -348,10 +321,7 @@ describe('AdminEvents', () => {
     describe('event detail modal', () => {
         it('opens event detail modal when row is clicked', async () => {
             const events = [createMockEvent({ event_id: 'evt-detail-1' })];
-            mocks.getEventDetailApiV1AdminEventsEventIdGet.mockResolvedValue({
-                data: createMockEventDetail(events[0]),
-                error: null,
-            });
+            mockApi(getEventDetailApiV1AdminEventsEventIdGet).ok(createMockEventDetail(events[0]));
             await renderWithEvents(events);
 
             // Multiple view detail buttons may exist (mobile + desktop views)
@@ -359,7 +329,7 @@ describe('AdminEvents', () => {
             await user.click(eventRow!);
 
             await waitFor(() => {
-                expect(mocks.getEventDetailApiV1AdminEventsEventIdGet).toHaveBeenCalledWith({
+                expect(vi.mocked(getEventDetailApiV1AdminEventsEventIdGet)).toHaveBeenCalledWith({
                     path: { event_id: 'evt-detail-1' },
                 });
                 expect(screen.getByText(/Event Details/i)).toBeInTheDocument();
@@ -368,10 +338,7 @@ describe('AdminEvents', () => {
 
         it('displays event information in modal', async () => {
             const event = createMockEvent({ event_id: 'evt-123', event_type: 'execution_completed' });
-            mocks.getEventDetailApiV1AdminEventsEventIdGet.mockResolvedValue({
-                data: createMockEventDetail(event),
-                error: null,
-            });
+            mockApi(getEventDetailApiV1AdminEventsEventIdGet).ok(createMockEventDetail(event));
             await renderWithEvents([event]);
 
             const [eventRow] = screen.getAllByRole('button', { name: /View details for event/i });
@@ -386,10 +353,7 @@ describe('AdminEvents', () => {
 
         it('shows related events in modal', async () => {
             const event = createMockEvent();
-            mocks.getEventDetailApiV1AdminEventsEventIdGet.mockResolvedValue({
-                data: createMockEventDetail(event),
-                error: null,
-            });
+            mockApi(getEventDetailApiV1AdminEventsEventIdGet).ok(createMockEventDetail(event));
             await renderWithEvents([event]);
 
             const [eventRow] = screen.getAllByRole('button', { name: /View details for event/i });
@@ -404,10 +368,7 @@ describe('AdminEvents', () => {
 
         it('has close button in modal', async () => {
             const event = createMockEvent();
-            mocks.getEventDetailApiV1AdminEventsEventIdGet.mockResolvedValue({
-                data: createMockEventDetail(event),
-                error: null,
-            });
+            mockApi(getEventDetailApiV1AdminEventsEventIdGet).ok(createMockEventDetail(event));
             await renderWithEvents([event]);
 
             const [eventRow] = screen.getAllByRole('button', { name: /View details for event/i });
@@ -424,9 +385,13 @@ describe('AdminEvents', () => {
     describe('replay functionality', () => {
         it('shows replay preview on dry run', async () => {
             const events = [createMockEvent({ event_id: 'evt-replay-1' })];
-            mocks.replayEventsApiV1AdminEventsReplayPost.mockResolvedValue({
-                data: { total_events: 1, events_preview: events, session_id: null },
-                error: null,
+            mockApi(replayEventsApiV1AdminEventsReplayPost).ok({
+                dry_run: true,
+                total_events: 1,
+                replay_id: '',
+                session_id: null,
+                status: 'preview',
+                events_preview: events,
             });
             await renderWithEvents(events);
 
@@ -434,7 +399,7 @@ describe('AdminEvents', () => {
             await user.click(previewBtn!);
 
             await waitFor(() => {
-                expect(mocks.replayEventsApiV1AdminEventsReplayPost).toHaveBeenCalledWith({
+                expect(vi.mocked(replayEventsApiV1AdminEventsReplayPost)).toHaveBeenCalledWith({
                     body: { event_ids: ['evt-replay-1'], dry_run: true },
                 });
                 expect(screen.getByText(/Replay Preview/i)).toBeInTheDocument();
@@ -443,9 +408,13 @@ describe('AdminEvents', () => {
 
         it('confirms before actual replay', async () => {
             const events = [createMockEvent({ event_id: 'evt-replay-2' })];
-            mocks.replayEventsApiV1AdminEventsReplayPost.mockResolvedValue({
-                data: { total_events: 1, session_id: 'session-1' },
-                error: null,
+            mockApi(replayEventsApiV1AdminEventsReplayPost).ok({
+                dry_run: false,
+                total_events: 1,
+                replay_id: 'replay-1',
+                session_id: 'session-1',
+                status: 'scheduled',
+                events_preview: null,
             });
             await renderWithEvents(events);
 
@@ -454,7 +423,7 @@ describe('AdminEvents', () => {
 
             expect(mocks.windowConfirm).toHaveBeenCalled();
             await waitFor(() => {
-                expect(mocks.replayEventsApiV1AdminEventsReplayPost).toHaveBeenCalledWith({
+                expect(vi.mocked(replayEventsApiV1AdminEventsReplayPost)).toHaveBeenCalledWith({
                     body: { event_ids: ['evt-replay-2'], dry_run: false },
                 });
             });
@@ -468,24 +437,25 @@ describe('AdminEvents', () => {
             const [replayBtn] = screen.getAllByTitle('Replay');
             await user.click(replayBtn!);
 
-            expect(mocks.replayEventsApiV1AdminEventsReplayPost).not.toHaveBeenCalled();
+            expect(vi.mocked(replayEventsApiV1AdminEventsReplayPost)).not.toHaveBeenCalled();
         });
 
         it('shows replay progress when session is active', async () => {
             const events = [createMockEvent({ event_id: 'evt-progress' })];
-            mocks.replayEventsApiV1AdminEventsReplayPost.mockResolvedValue({
-                data: { total_events: 5, session_id: 'session-progress' },
-                error: null,
+            mockApi(replayEventsApiV1AdminEventsReplayPost).ok({
+                dry_run: false,
+                total_events: 5,
+                replay_id: 'replay-p',
+                session_id: 'session-progress',
+                status: 'scheduled',
+                events_preview: null,
             });
-            mocks.getReplayStatusApiV1AdminEventsReplaySessionIdStatusGet.mockResolvedValue({
-                data: {
-                    session_id: 'session-progress',
-                    status: 'in_progress',
-                    total_events: 5,
-                    replayed_events: 2,
-                    progress_percentage: 40,
-                },
-                error: null,
+            mockApi(streamReplayStatusApiV1AdminEventsReplaySessionIdStatusGet).ok({
+                session_id: 'session-progress',
+                status: 'in_progress',
+                total_events: 5,
+                replayed_events: 2,
+                progress_percentage: 40,
             });
             await renderWithEvents(events);
 
@@ -501,7 +471,7 @@ describe('AdminEvents', () => {
     describe('delete event', () => {
         it('confirms before deleting', async () => {
             const events = [createMockEvent({ event_id: 'evt-delete-1' })];
-            mocks.deleteEventApiV1AdminEventsEventIdDelete.mockResolvedValue({ data: {}, error: null });
+            mockApi(deleteEventApiV1AdminEventsEventIdDelete).ok({});
             await renderWithEvents(events);
 
             const [deleteBtn] = screen.getAllByTitle('Delete');
@@ -509,7 +479,7 @@ describe('AdminEvents', () => {
 
             expect(mocks.windowConfirm).toHaveBeenCalled();
             await waitFor(() => {
-                expect(mocks.deleteEventApiV1AdminEventsEventIdDelete).toHaveBeenCalledWith({
+                expect(vi.mocked(deleteEventApiV1AdminEventsEventIdDelete)).toHaveBeenCalledWith({
                     path: { event_id: 'evt-delete-1' },
                 });
             });
@@ -517,14 +487,14 @@ describe('AdminEvents', () => {
 
         it('shows success toast after deletion', async () => {
             const events = [createMockEvent()];
-            mocks.deleteEventApiV1AdminEventsEventIdDelete.mockResolvedValue({ data: {}, error: null });
+            mockApi(deleteEventApiV1AdminEventsEventIdDelete).ok({});
             await renderWithEvents(events);
 
             const [deleteBtn] = screen.getAllByTitle('Delete');
             await user.click(deleteBtn!);
 
             await waitFor(() => {
-                expect(mocks.addToast).toHaveBeenCalledWith('Event deleted successfully');
+                expect(vi.mocked(toast.success)).toHaveBeenCalledWith('Event deleted successfully');
             });
         });
 
@@ -536,14 +506,14 @@ describe('AdminEvents', () => {
             const [deleteBtn] = screen.getAllByTitle('Delete');
             await user.click(deleteBtn!);
 
-            expect(mocks.deleteEventApiV1AdminEventsEventIdDelete).not.toHaveBeenCalled();
+            expect(vi.mocked(deleteEventApiV1AdminEventsEventIdDelete)).not.toHaveBeenCalled();
         });
 
         it('handles delete error and shows toast', async () => {
             const error = { message: 'Cannot delete' };
-            mocks.deleteEventApiV1AdminEventsEventIdDelete.mockImplementation(async () => {
-                mocks.addToast('Failed to delete event');
-                return { data: null, error };
+            vi.mocked(deleteEventApiV1AdminEventsEventIdDelete).mockImplementation(async () => {
+                toast.error('Failed to delete event');
+                return { data: null, error } as any;
             });
             const events = [createMockEvent()];
             await renderWithEvents(events);
@@ -552,7 +522,7 @@ describe('AdminEvents', () => {
             await user.click(deleteBtn!);
 
             await waitFor(() => {
-                expect(mocks.addToast).toHaveBeenCalledWith('Failed to delete event');
+                expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to delete event');
             });
         });
     });
@@ -582,7 +552,7 @@ describe('AdminEvents', () => {
                 expect.stringContaining('/api/v1/admin/events/export/csv'),
                 '_blank',
             );
-            expect(mocks.addToast).toHaveBeenCalledWith(expect.stringContaining('Starting CSV export'));
+            expect(vi.mocked(toast.info)).toHaveBeenCalledWith(expect.stringContaining('Starting CSV export'));
         });
 
         it('exports as JSON', async () => {
@@ -597,24 +567,21 @@ describe('AdminEvents', () => {
                 expect.stringContaining('/api/v1/admin/events/export/json'),
                 '_blank',
             );
-            expect(mocks.addToast).toHaveBeenCalledWith(expect.stringContaining('Starting JSON export'));
+            expect(vi.mocked(toast.info)).toHaveBeenCalledWith(expect.stringContaining('Starting JSON export'));
         });
     });
 
     describe('user overview modal', () => {
         it('opens user overview modal when user ID is clicked', async () => {
             const events = [createMockEvent({ metadata: { user_id: 'user-overview-1' } })];
-            mocks.getUserOverviewApiV1AdminUsersUserIdOverviewGet.mockResolvedValue({
-                data: createMockUserOverview(),
-                error: null,
-            });
+            mockApi(getUserOverviewApiV1AdminUsersUserIdOverviewGet).ok(createMockUserOverview());
             await renderWithEvents(events);
 
             const [userLink] = screen.getAllByText('user-overview-1');
             await user.click(userLink!);
 
             await waitFor(() => {
-                expect(mocks.getUserOverviewApiV1AdminUsersUserIdOverviewGet).toHaveBeenCalledWith({
+                expect(vi.mocked(getUserOverviewApiV1AdminUsersUserIdOverviewGet)).toHaveBeenCalledWith({
                     path: { user_id: 'user-overview-1' },
                 });
                 expect(screen.getByText(/User Overview/i)).toBeInTheDocument();
@@ -624,10 +591,7 @@ describe('AdminEvents', () => {
         it('displays user information in overview modal', async () => {
             const events = [createMockEvent({ metadata: { user_id: 'user-info' } })];
             const overview = createMockUserOverview();
-            mocks.getUserOverviewApiV1AdminUsersUserIdOverviewGet.mockResolvedValue({
-                data: overview,
-                error: null,
-            });
+            mockApi(getUserOverviewApiV1AdminUsersUserIdOverviewGet).ok(overview);
             await renderWithEvents(events);
 
             const [userLink] = screen.getAllByText('user-info');
@@ -641,10 +605,7 @@ describe('AdminEvents', () => {
 
         it('shows execution stats in overview modal', async () => {
             const events = [createMockEvent({ metadata: { user_id: 'user-stats' } })];
-            mocks.getUserOverviewApiV1AdminUsersUserIdOverviewGet.mockResolvedValue({
-                data: createMockUserOverview(),
-                error: null,
-            });
+            mockApi(getUserOverviewApiV1AdminUsersUserIdOverviewGet).ok(createMockUserOverview());
             await renderWithEvents(events);
 
             const [userLink] = screen.getAllByText('user-stats');
@@ -662,9 +623,9 @@ describe('AdminEvents', () => {
         it('handles user overview load error and shows toast', async () => {
             const error = { message: 'Failed to load' };
             const events = [createMockEvent({ metadata: { user_id: 'user-error' } })];
-            mocks.getUserOverviewApiV1AdminUsersUserIdOverviewGet.mockImplementation(async () => {
-                mocks.addToast('Failed to load user overview');
-                return { data: null, error };
+            vi.mocked(getUserOverviewApiV1AdminUsersUserIdOverviewGet).mockImplementation(async () => {
+                toast.error('Failed to load user overview');
+                return { data: null, error } as any;
             });
             await renderWithEvents(events);
 
@@ -672,7 +633,7 @@ describe('AdminEvents', () => {
             await user.click(userLink!);
 
             await waitFor(() => {
-                expect(mocks.addToast).toHaveBeenCalledWith('Failed to load user overview');
+                expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to load user overview');
             });
         });
     });
@@ -720,9 +681,9 @@ describe('AdminEvents', () => {
     describe('error handling', () => {
         it('handles event detail load error and shows toast', async () => {
             const error = { message: 'Detail not found' };
-            mocks.getEventDetailApiV1AdminEventsEventIdGet.mockImplementation(async () => {
-                mocks.addToast('Failed to load event details');
-                return { data: null, error };
+            vi.mocked(getEventDetailApiV1AdminEventsEventIdGet).mockImplementation(async () => {
+                toast.error('Failed to load event details');
+                return { data: null, error } as any;
             });
             const events = [createMockEvent()];
             await renderWithEvents(events);
@@ -731,15 +692,15 @@ describe('AdminEvents', () => {
             await user.click(eventRow!);
 
             await waitFor(() => {
-                expect(mocks.addToast).toHaveBeenCalledWith('Failed to load event details');
+                expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to load event details');
             });
         });
 
         it('handles replay error and shows toast', async () => {
             const error = { message: 'Replay failed' };
-            mocks.replayEventsApiV1AdminEventsReplayPost.mockImplementation(async () => {
-                mocks.addToast('Failed to replay event');
-                return { data: null, error };
+            vi.mocked(replayEventsApiV1AdminEventsReplayPost).mockImplementation(async () => {
+                toast.error('Failed to replay event');
+                return { data: null, error } as any;
             });
             const events = [createMockEvent()];
             await renderWithEvents(events);
@@ -748,7 +709,7 @@ describe('AdminEvents', () => {
             await user.click(replayBtn!);
 
             await waitFor(() => {
-                expect(mocks.addToast).toHaveBeenCalledWith('Failed to replay event');
+                expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to replay event');
             });
         });
     });

--- a/frontend/src/routes/admin/__tests__/AdminExecutions.test.ts
+++ b/frontend/src/routes/admin/__tests__/AdminExecutions.test.ts
@@ -1,37 +1,21 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
-import { user, selectOption, createMockExecution, createMockExecutions, createMockQueueStatus } from '$test/test-utils';
+import {
+    user,
+    selectOption,
+    createMockExecution,
+    createMockExecutions,
+    createMockQueueStatus,
+    mockApi,
+} from '$test/test-utils';
+import {
+    listExecutionsApiV1AdminExecutionsGet,
+    updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut,
+    getQueueStatusApiV1AdminExecutionsQueueGet,
+} from '$lib/api';
+import { toast } from 'svelte-sonner';
 
-const mocks = vi.hoisted(() => ({
-    listExecutionsApiV1AdminExecutionsGet: vi.fn(),
-    updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut: vi.fn(),
-    getQueueStatusApiV1AdminExecutionsQueueGet: vi.fn(),
-    addToast: vi.fn(),
-}));
-
-vi.mock('../../../lib/api', () => ({
-    listExecutionsApiV1AdminExecutionsGet: (...args: unknown[]) => mocks.listExecutionsApiV1AdminExecutionsGet(...args),
-    updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut: (...args: unknown[]) =>
-        mocks.updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut(...args),
-    getQueueStatusApiV1AdminExecutionsQueueGet: (...args: unknown[]) =>
-        mocks.getQueueStatusApiV1AdminExecutionsQueueGet(...args),
-}));
-
-vi.mock('svelte-sonner', () => ({
-    toast: {
-        success: (...args: unknown[]) => mocks.addToast('success', ...args),
-        error: (...args: unknown[]) => mocks.addToast('error', ...args),
-        warning: (...args: unknown[]) => mocks.addToast('warning', ...args),
-        info: (...args: unknown[]) => mocks.addToast('info', ...args),
-    },
-}));
-
-vi.mock('../../../lib/api-interceptors', async (importOriginal) => {
-    const actual = (await importOriginal()) as Record<string, unknown>;
-    return { ...actual };
-});
-
-vi.mock('../AdminLayout.svelte', async () => {
+vi.mock('$routes/admin/AdminLayout.svelte', async () => {
     const { default: MockLayout } = await import('$routes/admin/__tests__/mocks/MockAdminLayout.svelte');
     return { default: MockLayout };
 });
@@ -39,43 +23,40 @@ vi.mock('../AdminLayout.svelte', async () => {
 import AdminExecutions from '$routes/admin/AdminExecutions.svelte';
 
 async function renderWithExecutions(executions = createMockExecutions(5), queueStatus = createMockQueueStatus()) {
-    mocks.listExecutionsApiV1AdminExecutionsGet.mockResolvedValue({
-        data: { executions, total: executions.length, limit: 20, skip: 0, has_more: false },
-        error: null,
+    mockApi(listExecutionsApiV1AdminExecutionsGet).ok({
+        executions,
+        total: executions.length,
+        limit: 20,
+        skip: 0,
+        has_more: false,
     });
-    mocks.getQueueStatusApiV1AdminExecutionsQueueGet.mockResolvedValue({
-        data: queueStatus,
-        error: null,
-    });
+    mockApi(getQueueStatusApiV1AdminExecutionsQueueGet).ok(queueStatus);
 
     const result = render(AdminExecutions);
-    await waitFor(() => expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalled());
+    await waitFor(() => expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalled());
     return result;
 }
 
 describe('AdminExecutions', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        mocks.listExecutionsApiV1AdminExecutionsGet.mockResolvedValue({
-            data: { executions: [], total: 0, limit: 20, skip: 0, has_more: false },
-            error: null,
+        mockApi(listExecutionsApiV1AdminExecutionsGet).ok({
+            executions: [],
+            total: 0,
+            limit: 20,
+            skip: 0,
+            has_more: false,
         });
-        mocks.getQueueStatusApiV1AdminExecutionsQueueGet.mockResolvedValue({
-            data: createMockQueueStatus(),
-            error: null,
-        });
-        mocks.updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut.mockResolvedValue({
-            data: null,
-            error: null,
-        });
+        mockApi(getQueueStatusApiV1AdminExecutionsQueueGet).ok(createMockQueueStatus());
+        mockApi(updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut).ok(null);
     });
 
     describe('initial loading', () => {
         it('calls API on mount', async () => {
             render(AdminExecutions);
             await waitFor(() => {
-                expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalled();
-                expect(mocks.getQueueStatusApiV1AdminExecutionsQueueGet).toHaveBeenCalled();
+                expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalled();
+                expect(vi.mocked(getQueueStatusApiV1AdminExecutionsQueueGet)).toHaveBeenCalled();
             });
         });
 
@@ -117,7 +98,7 @@ describe('AdminExecutions', () => {
             selectOption(statusSelect, 'running');
 
             await waitFor(() => {
-                expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledWith(
+                expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         query: expect.objectContaining({ status: 'running' }),
                     }),
@@ -133,7 +114,7 @@ describe('AdminExecutions', () => {
             selectOption(prioritySelect!, 'high');
 
             await waitFor(() => {
-                expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledWith(
+                expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         query: expect.objectContaining({ priority: 'high' }),
                     }),
@@ -149,7 +130,7 @@ describe('AdminExecutions', () => {
             await user.type(userInput, 'user-42');
 
             await waitFor(() => {
-                expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledWith(
+                expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         query: expect.objectContaining({ user_id: 'user-42' }),
                     }),
@@ -168,7 +149,7 @@ describe('AdminExecutions', () => {
             await user.click(resetButton);
 
             await waitFor(() => {
-                expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledWith(
+                expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         query: expect.objectContaining({ status: undefined }),
                     }),
@@ -202,17 +183,14 @@ describe('AdminExecutions', () => {
     describe('priority update', () => {
         it('successful update shows success toast', async () => {
             const execs = [createMockExecution({ execution_id: 'e1', priority: 'normal' })];
-            mocks.updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut.mockResolvedValue({
-                data: { ...execs[0], priority: 'high' },
-                error: null,
-            });
+            mockApi(updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut).ok({ ...execs[0], priority: 'high' });
             await renderWithExecutions(execs);
 
             const [prioritySelect] = screen.getAllByDisplayValue('normal');
             selectOption(prioritySelect!, 'high');
 
             await waitFor(() => {
-                expect(mocks.updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut).toHaveBeenCalledWith(
+                expect(vi.mocked(updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         path: { execution_id: 'e1' },
                         body: { priority: 'high' },
@@ -221,43 +199,40 @@ describe('AdminExecutions', () => {
             });
 
             await waitFor(() => {
-                expect(mocks.addToast).toHaveBeenCalledWith('success', expect.stringContaining('high'));
+                expect(vi.mocked(toast.success)).toHaveBeenCalledWith(expect.stringContaining('high'));
             });
         });
 
         it('failed update calls API and does not show success toast', async () => {
             const execs = [createMockExecution({ execution_id: 'e1', priority: 'normal' })];
-            mocks.updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut.mockResolvedValue({
-                data: undefined,
-                error: { detail: 'Not found' },
-            });
+            mockApi(updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut).err({ detail: 'Not found' });
             await renderWithExecutions(execs);
 
             const [prioritySelect] = screen.getAllByDisplayValue('normal');
             selectOption(prioritySelect!, 'critical');
 
             await waitFor(() => {
-                expect(mocks.updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut).toHaveBeenCalledWith(
+                expect(vi.mocked(updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         path: { execution_id: 'e1' },
                         body: { priority: 'critical' },
                     }),
                 );
             });
-            expect(mocks.addToast).not.toHaveBeenCalledWith('success', expect.anything());
+            expect(vi.mocked(toast.success)).not.toHaveBeenCalledWith(expect.anything());
         });
     });
 
     describe('auto-refresh', () => {
         it('auto-refreshes at 5s interval', async () => {
             await renderWithExecutions();
-            const initialCalls = mocks.listExecutionsApiV1AdminExecutionsGet.mock.calls.length;
+            const initialCalls = vi.mocked(listExecutionsApiV1AdminExecutionsGet).mock.calls.length;
 
             await vi.advanceTimersByTimeAsync(5000);
-            expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledTimes(initialCalls + 1);
+            expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledTimes(initialCalls + 1);
 
             await vi.advanceTimersByTimeAsync(5000);
-            expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledTimes(initialCalls + 2);
+            expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalledTimes(initialCalls + 2);
         });
 
         it('manual refresh button calls loadData', async () => {
@@ -268,8 +243,8 @@ describe('AdminExecutions', () => {
             await user.click(refreshButton);
 
             await waitFor(() => {
-                expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalled();
-                expect(mocks.getQueueStatusApiV1AdminExecutionsQueueGet).toHaveBeenCalled();
+                expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalled();
+                expect(vi.mocked(getQueueStatusApiV1AdminExecutionsQueueGet)).toHaveBeenCalled();
             });
         });
     });
@@ -277,17 +252,17 @@ describe('AdminExecutions', () => {
     describe('pagination', () => {
         it('shows pagination when totalPages > 1', async () => {
             const execs = createMockExecutions(5);
-            mocks.listExecutionsApiV1AdminExecutionsGet.mockResolvedValue({
-                data: { executions: execs, total: 50, limit: 20, skip: 0, has_more: true },
-                error: null,
+            mockApi(listExecutionsApiV1AdminExecutionsGet).ok({
+                executions: execs,
+                total: 50,
+                limit: 20,
+                skip: 0,
+                has_more: true,
             });
-            mocks.getQueueStatusApiV1AdminExecutionsQueueGet.mockResolvedValue({
-                data: createMockQueueStatus(),
-                error: null,
-            });
+            mockApi(getQueueStatusApiV1AdminExecutionsQueueGet).ok(createMockQueueStatus());
 
             render(AdminExecutions);
-            await waitFor(() => expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalled());
+            await waitFor(() => expect(vi.mocked(listExecutionsApiV1AdminExecutionsGet)).toHaveBeenCalled());
 
             expect(screen.getByText(/showing/i)).toBeInTheDocument();
         });

--- a/frontend/src/routes/admin/__tests__/AdminExecutions.test.ts
+++ b/frontend/src/routes/admin/__tests__/AdminExecutions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
-import { user, createMockExecution, createMockExecutions, createMockQueueStatus } from '$test/test-utils';
+import { user, selectOption, createMockExecution, createMockExecutions, createMockQueueStatus } from '$test/test-utils';
 
 const mocks = vi.hoisted(() => ({
     listExecutionsApiV1AdminExecutionsGet: vi.fn(),
@@ -114,7 +114,7 @@ describe('AdminExecutions', () => {
             vi.clearAllMocks();
 
             const statusSelect = screen.getByLabelText(/status/i);
-            await user.selectOptions(statusSelect, 'running');
+            selectOption(statusSelect, 'running');
 
             await waitFor(() => {
                 expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledWith(
@@ -130,7 +130,7 @@ describe('AdminExecutions', () => {
             vi.clearAllMocks();
 
             const prioritySelect = screen.getByLabelText('Priority');
-            await user.selectOptions(prioritySelect!, 'high');
+            selectOption(prioritySelect!, 'high');
 
             await waitFor(() => {
                 expect(mocks.listExecutionsApiV1AdminExecutionsGet).toHaveBeenCalledWith(
@@ -161,7 +161,7 @@ describe('AdminExecutions', () => {
             await renderWithExecutions();
 
             const statusSelect = screen.getByLabelText(/status/i);
-            await user.selectOptions(statusSelect, 'running');
+            selectOption(statusSelect, 'running');
 
             vi.clearAllMocks();
             const resetButton = screen.getByRole('button', { name: /reset/i });
@@ -209,7 +209,7 @@ describe('AdminExecutions', () => {
             await renderWithExecutions(execs);
 
             const [prioritySelect] = screen.getAllByDisplayValue('normal');
-            await user.selectOptions(prioritySelect!, 'high');
+            selectOption(prioritySelect!, 'high');
 
             await waitFor(() => {
                 expect(mocks.updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut).toHaveBeenCalledWith(
@@ -234,7 +234,7 @@ describe('AdminExecutions', () => {
             await renderWithExecutions(execs);
 
             const [prioritySelect] = screen.getAllByDisplayValue('normal');
-            await user.selectOptions(prioritySelect!, 'critical');
+            selectOption(prioritySelect!, 'critical');
 
             await waitFor(() => {
                 expect(mocks.updatePriorityApiV1AdminExecutionsExecutionIdPriorityPut).toHaveBeenCalledWith(

--- a/frontend/src/routes/admin/__tests__/AdminLayout.test.ts
+++ b/frontend/src/routes/admin/__tests__/AdminLayout.test.ts
@@ -18,15 +18,9 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('$stores/auth.svelte', () => ({ authStore: mocks.mockAuthStore }));
 
-vi.mock('@mateothegreat/svelte5-router', () => ({ route: () => {}, goto: vi.fn() }));
-
 describe('AdminLayout', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        vi.spyOn(toast, 'success');
-        vi.spyOn(toast, 'error');
-        vi.spyOn(toast, 'warning');
-        vi.spyOn(toast, 'info');
         mocks.mockAuthStore.userRole = 'admin';
         mocks.mockAuthStore.username = 'adminuser';
     });

--- a/frontend/src/routes/admin/__tests__/AdminSagas.test.ts
+++ b/frontend/src/routes/admin/__tests__/AdminSagas.test.ts
@@ -1,20 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { user, selectOption, createMockSaga, createMockSagas } from '$test/test-utils';
+import { user, selectOption, createMockSaga, createMockSagas, mockApi } from '$test/test-utils';
+import { listSagasApiV1SagasGet, getSagaStatusApiV1SagasSagaIdGet } from '$lib/api';
 
-const mocks = vi.hoisted(() => ({
-    listSagasApiV1SagasGet: vi.fn(),
-    getSagaStatusApiV1SagasSagaIdGet: vi.fn(),
-}));
-
-vi.mock('../../../lib/api', () => ({
-    listSagasApiV1SagasGet: (...args: unknown[]) => mocks.listSagasApiV1SagasGet(...args),
-    getSagaStatusApiV1SagasSagaIdGet: (...args: unknown[]) => mocks.getSagaStatusApiV1SagasSagaIdGet(...args),
-}));
-
-vi.mock('../../../lib/api-interceptors');
-vi.mock('../AdminLayout.svelte', async () => {
+vi.mock('$routes/admin/AdminLayout.svelte', async () => {
     const { default: MockLayout } = await import('$routes/admin/__tests__/mocks/MockAdminLayout.svelte');
     return { default: MockLayout };
 });
@@ -22,31 +12,28 @@ vi.mock('../AdminLayout.svelte', async () => {
 import AdminSagas from '$routes/admin/AdminSagas.svelte';
 
 async function renderWithSagas(sagas = createMockSagas(5)) {
-    mocks.listSagasApiV1SagasGet.mockResolvedValue({
-        data: { sagas, total: sagas.length },
-        error: null,
-    });
+    mockApi(listSagasApiV1SagasGet).ok({ sagas, total: sagas.length, skip: 0, limit: 10, has_more: false });
 
     const result = render(AdminSagas);
-    await waitFor(() => expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalled());
+    await waitFor(() => expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalled());
     return result;
 }
 
 describe('AdminSagas', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        mocks.listSagasApiV1SagasGet.mockResolvedValue({ data: { sagas: [], total: 0 }, error: null });
-        mocks.getSagaStatusApiV1SagasSagaIdGet.mockResolvedValue({ data: null, error: null });
+        mockApi(listSagasApiV1SagasGet).ok({ sagas: [], total: 0, skip: 0, limit: 10, has_more: false });
+        mockApi(getSagaStatusApiV1SagasSagaIdGet).ok(undefined);
     });
 
     describe('initial loading', () => {
         it('calls listSagas on mount', async () => {
             render(AdminSagas);
-            await waitFor(() => expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalled());
+            await waitFor(() => expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalled());
         });
 
         it('displays loading state', async () => {
-            mocks.listSagasApiV1SagasGet.mockImplementation(() => new Promise(() => {}));
+            mockApi(listSagasApiV1SagasGet).mock.mockImplementation(() => new Promise(() => {}));
             render(AdminSagas);
             await tick();
             expect(screen.getByText(/loading sagas/i)).toBeInTheDocument();
@@ -107,13 +94,13 @@ describe('AdminSagas', () => {
     describe('auto-refresh', () => {
         it('auto-refreshes at specified interval', async () => {
             await renderWithSagas();
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledTimes(1);
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledTimes(1);
 
             await vi.advanceTimersByTimeAsync(5000);
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledTimes(2);
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledTimes(2);
 
             await vi.advanceTimersByTimeAsync(5000);
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledTimes(3);
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledTimes(3);
         });
 
         it('manual refresh button works', async () => {
@@ -123,7 +110,7 @@ describe('AdminSagas', () => {
             const refreshButton = screen.getByRole('button', { name: /refresh now/i });
             await user.click(refreshButton);
 
-            await waitFor(() => expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalled());
+            await waitFor(() => expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalled());
         });
 
         it('toggling auto-refresh off stops polling', async () => {
@@ -135,7 +122,7 @@ describe('AdminSagas', () => {
             vi.clearAllMocks();
             await vi.advanceTimersByTimeAsync(10000);
 
-            expect(mocks.listSagasApiV1SagasGet).not.toHaveBeenCalled();
+            expect(vi.mocked(listSagasApiV1SagasGet)).not.toHaveBeenCalled();
         });
     });
 
@@ -148,7 +135,7 @@ describe('AdminSagas', () => {
             selectOption(stateSelect, 'running');
 
             await waitFor(() => {
-                expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledWith(
+                expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         query: expect.objectContaining({ state: 'running' }),
                     }),
@@ -179,16 +166,13 @@ describe('AdminSagas', () => {
             await renderWithSagas(sagas);
 
             const matchingSaga = [createMockSaga({ saga_id: 's1', execution_id: 'exec-abc' })];
-            mocks.listSagasApiV1SagasGet.mockResolvedValue({
-                data: { sagas: matchingSaga, total: 1 },
-                error: null,
-            });
+            mockApi(listSagasApiV1SagasGet).ok({ sagas: matchingSaga, total: 1, skip: 0, limit: 10, has_more: false });
 
             const execInput = screen.getByLabelText(/execution id/i);
             await user.type(execInput, 'abc');
 
             await waitFor(() => {
-                expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledWith(
+                expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         query: expect.objectContaining({ execution_id: 'abc' }),
                     }),
@@ -208,7 +192,7 @@ describe('AdminSagas', () => {
             await user.click(clearButton);
 
             await waitFor(() => {
-                expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledWith(
+                expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         query: expect.objectContaining({ state: undefined }),
                     }),
@@ -223,7 +207,7 @@ describe('AdminSagas', () => {
                 saga_name: 'execution_saga',
                 completed_steps: ['validate_execution', 'allocate_resources'],
             });
-            mocks.getSagaStatusApiV1SagasSagaIdGet.mockResolvedValue({ data: saga, error: null });
+            mockApi(getSagaStatusApiV1SagasSagaIdGet).ok(saga);
             await renderWithSagas([saga]);
 
             const [viewBtn] = screen.getAllByRole('button', { name: /view details/i });
@@ -241,7 +225,7 @@ describe('AdminSagas', () => {
                 completed_steps: ['validate_execution'],
                 retry_count: 2,
             });
-            mocks.getSagaStatusApiV1SagasSagaIdGet.mockResolvedValue({ data: saga, error: null });
+            mockApi(getSagaStatusApiV1SagasSagaIdGet).ok(saga);
             await renderWithSagas([saga]);
 
             const [viewBtn] = screen.getAllByRole('button', { name: /view details/i });
@@ -257,7 +241,7 @@ describe('AdminSagas', () => {
                 state: 'failed',
                 error_message: 'Pod creation failed: timeout',
             });
-            mocks.getSagaStatusApiV1SagasSagaIdGet.mockResolvedValue({ data: saga, error: null });
+            mockApi(getSagaStatusApiV1SagasSagaIdGet).ok(saga);
             await renderWithSagas([saga]);
 
             const [viewBtn] = screen.getAllByRole('button', { name: /view details/i });
@@ -270,7 +254,7 @@ describe('AdminSagas', () => {
 
         it('closes modal on close button click', async () => {
             const saga = createMockSaga();
-            mocks.getSagaStatusApiV1SagasSagaIdGet.mockResolvedValue({ data: saga, error: null });
+            mockApi(getSagaStatusApiV1SagasSagaIdGet).ok(saga);
             await renderWithSagas([saga]);
 
             const [viewBtn] = screen.getAllByRole('button', { name: /view details/i });
@@ -291,7 +275,7 @@ describe('AdminSagas', () => {
                 completed_steps: ['validate_execution', 'allocate_resources'],
                 compensated_steps: ['release_resources'],
             });
-            mocks.getSagaStatusApiV1SagasSagaIdGet.mockResolvedValue({ data: saga, error: null });
+            mockApi(getSagaStatusApiV1SagasSagaIdGet).ok(saga);
             await renderWithSagas([saga]);
 
             const [viewBtn] = screen.getAllByRole('button', { name: /view details/i });
@@ -305,16 +289,19 @@ describe('AdminSagas', () => {
     describe('view execution sagas', () => {
         it('loads sagas for specific execution', async () => {
             const executionSagas = [createMockSaga({ execution_id: 'exec-target' })];
-            mocks.listSagasApiV1SagasGet.mockResolvedValue({
-                data: { sagas: executionSagas, total: 1 },
-                error: null,
+            mockApi(listSagasApiV1SagasGet).ok({
+                sagas: executionSagas,
+                total: 1,
+                skip: 0,
+                limit: 10,
+                has_more: false,
             });
             await renderWithSagas([createMockSaga({ execution_id: 'exec-target' })]);
 
             const [execButton] = screen.getAllByRole('button', { name: /execution/i });
             await user.click(execButton!);
             await waitFor(() => {
-                expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledWith(
+                expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         query: expect.objectContaining({ execution_id: 'exec-target' }),
                     }),
@@ -326,33 +313,27 @@ describe('AdminSagas', () => {
     describe('pagination', () => {
         it('shows pagination when items exist', async () => {
             const sagas = createMockSagas(5);
-            mocks.listSagasApiV1SagasGet.mockResolvedValue({
-                data: { sagas, total: 25 },
-                error: null,
-            });
+            mockApi(listSagasApiV1SagasGet).ok({ sagas, total: 25, skip: 0, limit: 10, has_more: true });
 
             render(AdminSagas);
-            await waitFor(() => expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalled());
+            await waitFor(() => expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalled());
 
             expect(screen.getByText(/showing/i)).toBeInTheDocument();
         });
 
         it('changes page size', async () => {
             const sagas = createMockSagas(5);
-            mocks.listSagasApiV1SagasGet.mockResolvedValue({
-                data: { sagas, total: 25 },
-                error: null,
-            });
+            mockApi(listSagasApiV1SagasGet).ok({ sagas, total: 25, skip: 0, limit: 10, has_more: true });
 
             render(AdminSagas);
-            await waitFor(() => expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalled());
+            await waitFor(() => expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalled());
 
             vi.clearAllMocks();
             const pageSizeSelect = screen.getByDisplayValue('10 / page');
             selectOption(pageSizeSelect, '25');
 
             await waitFor(() => {
-                expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledWith(
+                expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledWith(
                     expect.objectContaining({
                         query: expect.objectContaining({ limit: 25 }),
                     }),
@@ -371,7 +352,7 @@ describe('AdminSagas', () => {
             vi.clearAllMocks();
             await vi.advanceTimersByTimeAsync(10000);
 
-            expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledTimes(1);
+            expect(vi.mocked(listSagasApiV1SagasGet)).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/frontend/src/routes/admin/__tests__/AdminSagas.test.ts
+++ b/frontend/src/routes/admin/__tests__/AdminSagas.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { user, createMockSaga, createMockSagas } from '$test/test-utils';
+import { user, selectOption, createMockSaga, createMockSagas } from '$test/test-utils';
 
 const mocks = vi.hoisted(() => ({
     listSagasApiV1SagasGet: vi.fn(),
@@ -145,7 +145,7 @@ describe('AdminSagas', () => {
             vi.clearAllMocks();
 
             const stateSelect = screen.getByLabelText(/state/i);
-            await user.selectOptions(stateSelect, 'running');
+            selectOption(stateSelect, 'running');
 
             await waitFor(() => {
                 expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledWith(
@@ -201,7 +201,7 @@ describe('AdminSagas', () => {
             await renderWithSagas();
 
             const stateSelect = screen.getByLabelText(/state/i);
-            await user.selectOptions(stateSelect, 'failed');
+            selectOption(stateSelect, 'failed');
 
             vi.clearAllMocks();
             const clearButton = screen.getByRole('button', { name: /clear filters/i });
@@ -349,7 +349,7 @@ describe('AdminSagas', () => {
 
             vi.clearAllMocks();
             const pageSizeSelect = screen.getByDisplayValue('10 / page');
-            await user.selectOptions(pageSizeSelect, '25');
+            selectOption(pageSizeSelect, '25');
 
             await waitFor(() => {
                 expect(mocks.listSagasApiV1SagasGet).toHaveBeenCalledWith(
@@ -366,7 +366,7 @@ describe('AdminSagas', () => {
             await renderWithSagas();
 
             const rateSelect = screen.getByLabelText(/every/i);
-            await user.selectOptions(rateSelect, '10');
+            selectOption(rateSelect, '10');
 
             vi.clearAllMocks();
             await vi.advanceTimersByTimeAsync(10000);

--- a/frontend/src/routes/admin/__tests__/AdminSettings.test.ts
+++ b/frontend/src/routes/admin/__tests__/AdminSettings.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
-import { user } from '$test/test-utils';
+import { user, mockApi } from '$test/test-utils';
 import { toast } from 'svelte-sonner';
 import AdminSettings from '$routes/admin/AdminSettings.svelte';
 
@@ -21,10 +21,13 @@ function createMockSystemSettings() {
     };
 }
 
+import {
+    getSystemSettingsApiV1AdminSettingsGet,
+    updateSystemSettingsApiV1AdminSettingsPut,
+    resetSystemSettingsApiV1AdminSettingsResetPost,
+} from '$lib/api';
+
 const mocks = vi.hoisted(() => ({
-    getSystemSettingsApiV1AdminSettingsGet: vi.fn(),
-    updateSystemSettingsApiV1AdminSettingsPut: vi.fn(),
-    resetSystemSettingsApiV1AdminSettingsResetPost: vi.fn(),
     mockConfirm: vi.fn(),
     mockAuthStore: {
         isAuthenticated: true,
@@ -34,15 +37,6 @@ const mocks = vi.hoisted(() => ({
     },
 }));
 
-vi.mock('../../../lib/api', () => ({
-    getSystemSettingsApiV1AdminSettingsGet: (...args: unknown[]) =>
-        mocks.getSystemSettingsApiV1AdminSettingsGet(...args),
-    updateSystemSettingsApiV1AdminSettingsPut: (...args: unknown[]) =>
-        mocks.updateSystemSettingsApiV1AdminSettingsPut(...args),
-    resetSystemSettingsApiV1AdminSettingsResetPost: (...args: unknown[]) =>
-        mocks.resetSystemSettingsApiV1AdminSettingsResetPost(...args),
-}));
-
 vi.mock('$stores/auth.svelte', () => ({ authStore: mocks.mockAuthStore }));
 
 vi.mock('$routes/admin/AdminLayout.svelte', () => import('$routes/admin/__tests__/mocks/MockAdminLayout.svelte'));
@@ -50,23 +44,10 @@ vi.mock('$routes/admin/AdminLayout.svelte', () => import('$routes/admin/__tests_
 describe('AdminSettings', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        vi.spyOn(toast, 'success');
-        vi.spyOn(toast, 'error');
-        vi.spyOn(toast, 'warning');
-        vi.spyOn(toast, 'info');
         vi.stubGlobal('confirm', mocks.mockConfirm);
-        mocks.getSystemSettingsApiV1AdminSettingsGet.mockResolvedValue({
-            data: createMockSystemSettings(),
-            error: undefined,
-        });
-        mocks.updateSystemSettingsApiV1AdminSettingsPut.mockResolvedValue({
-            data: createMockSystemSettings(),
-            error: undefined,
-        });
-        mocks.resetSystemSettingsApiV1AdminSettingsResetPost.mockResolvedValue({
-            data: createMockSystemSettings(),
-            error: undefined,
-        });
+        mockApi(getSystemSettingsApiV1AdminSettingsGet).ok(createMockSystemSettings());
+        mockApi(updateSystemSettingsApiV1AdminSettingsPut).ok(createMockSystemSettings());
+        mockApi(resetSystemSettingsApiV1AdminSettingsResetPost).ok(createMockSystemSettings());
     });
 
     afterEach(() => vi.unstubAllGlobals());
@@ -79,7 +60,7 @@ describe('AdminSettings', () => {
         it('calls API on mount and shows page heading', async () => {
             await renderAdminSettings();
             await waitFor(() => {
-                expect(mocks.getSystemSettingsApiV1AdminSettingsGet).toHaveBeenCalledOnce();
+                expect(vi.mocked(getSystemSettingsApiV1AdminSettingsGet)).toHaveBeenCalledOnce();
             });
             expect(screen.getByRole('heading', { name: 'System Settings' })).toBeInTheDocument();
         });
@@ -122,9 +103,9 @@ describe('AdminSettings', () => {
 
             await user.click(screen.getByRole('button', { name: /save settings/i }));
             await waitFor(() => {
-                expect(mocks.updateSystemSettingsApiV1AdminSettingsPut).toHaveBeenCalled();
+                expect(vi.mocked(updateSystemSettingsApiV1AdminSettingsPut)).toHaveBeenCalled();
             });
-            const callArgs = mocks.updateSystemSettingsApiV1AdminSettingsPut.mock.calls[0]![0];
+            const callArgs = vi.mocked(updateSystemSettingsApiV1AdminSettingsPut).mock.calls[0]![0];
             expect(callArgs.body).toHaveProperty('max_timeout_seconds');
             expect(callArgs.body).toHaveProperty('password_min_length');
             expect(callArgs.body).toHaveProperty('metrics_retention_days');
@@ -132,17 +113,14 @@ describe('AdminSettings', () => {
         });
 
         it('handles save error without crashing', async () => {
-            mocks.updateSystemSettingsApiV1AdminSettingsPut.mockResolvedValue({
-                data: undefined,
-                error: { detail: 'Save failed' },
-            });
+            mockApi(updateSystemSettingsApiV1AdminSettingsPut).err({ detail: 'Save failed' });
             await renderAdminSettings();
             await waitFor(() => {
                 expect(screen.getByRole('button', { name: /save settings/i })).toBeInTheDocument();
             });
             await user.click(screen.getByRole('button', { name: /save settings/i }));
             await waitFor(() => {
-                expect(mocks.updateSystemSettingsApiV1AdminSettingsPut).toHaveBeenCalled();
+                expect(vi.mocked(updateSystemSettingsApiV1AdminSettingsPut)).toHaveBeenCalled();
             });
             expect(toast.success).not.toHaveBeenCalledWith('Settings saved successfully');
         });
@@ -165,10 +143,7 @@ describe('AdminSettings', () => {
                 enable_tracing: false,
                 sampling_rate: 1.0,
             };
-            mocks.resetSystemSettingsApiV1AdminSettingsResetPost.mockResolvedValue({
-                data: resetData,
-                error: undefined,
-            });
+            mockApi(resetSystemSettingsApiV1AdminSettingsResetPost).ok(resetData);
 
             await renderAdminSettings();
             await waitFor(() => {
@@ -178,7 +153,7 @@ describe('AdminSettings', () => {
             await user.click(screen.getByRole('button', { name: /reset to defaults/i }));
             expect(mocks.mockConfirm).toHaveBeenCalled();
             await waitFor(() => {
-                expect(mocks.resetSystemSettingsApiV1AdminSettingsResetPost).toHaveBeenCalled();
+                expect(vi.mocked(resetSystemSettingsApiV1AdminSettingsResetPost)).toHaveBeenCalled();
             });
             expect(toast.success).toHaveBeenCalledWith('Settings reset to defaults');
 
@@ -196,14 +171,14 @@ describe('AdminSettings', () => {
             });
 
             await user.click(screen.getByRole('button', { name: /reset to defaults/i }));
-            expect(mocks.resetSystemSettingsApiV1AdminSettingsResetPost).not.toHaveBeenCalled();
+            expect(vi.mocked(resetSystemSettingsApiV1AdminSettingsResetPost)).not.toHaveBeenCalled();
         });
     });
 
     describe('Button states', () => {
         it('disables both buttons while saving', async () => {
             let resolveSave: (v: unknown) => void;
-            mocks.updateSystemSettingsApiV1AdminSettingsPut.mockImplementation(
+            mockApi(updateSystemSettingsApiV1AdminSettingsPut).mock.mockImplementation(
                 () =>
                     new Promise((r) => {
                         resolveSave = r;
@@ -231,7 +206,7 @@ describe('AdminSettings', () => {
         it('shows "Resetting..." text while resetting', async () => {
             mocks.mockConfirm.mockReturnValue(true);
             let resolveReset: (v: unknown) => void;
-            mocks.resetSystemSettingsApiV1AdminSettingsResetPost.mockImplementation(
+            mockApi(resetSystemSettingsApiV1AdminSettingsResetPost).mock.mockImplementation(
                 () =>
                     new Promise((r) => {
                         resolveReset = r;

--- a/frontend/src/routes/admin/__tests__/AdminUsers.test.ts
+++ b/frontend/src/routes/admin/__tests__/AdminUsers.test.ts
@@ -1,49 +1,24 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/svelte';
-import { user, selectOption, createMockUser, createMockUsers } from '$test/test-utils';
-
-const mocks = vi.hoisted(() => ({
-    listUsersApiV1AdminUsersGet: vi.fn(),
-    createUserApiV1AdminUsersPost: vi.fn(),
-    updateUserApiV1AdminUsersUserIdPut: vi.fn(),
-    deleteUserApiV1AdminUsersUserIdDelete: vi.fn(),
-    getUserRateLimitsApiV1AdminRateLimitsUserIdGet: vi.fn(),
-    updateUserRateLimitsApiV1AdminRateLimitsUserIdPut: vi.fn(),
-    resetUserRateLimitsApiV1AdminRateLimitsUserIdResetPost: vi.fn(),
-    getDefaultRateLimitRulesApiV1AdminRateLimitsDefaultsGet: vi.fn(),
-    addToast: vi.fn(),
-}));
-
-vi.mock('$lib/api', () => ({
-    listUsersApiV1AdminUsersGet: mocks.listUsersApiV1AdminUsersGet,
-    createUserApiV1AdminUsersPost: mocks.createUserApiV1AdminUsersPost,
-    updateUserApiV1AdminUsersUserIdPut: mocks.updateUserApiV1AdminUsersUserIdPut,
-    deleteUserApiV1AdminUsersUserIdDelete: mocks.deleteUserApiV1AdminUsersUserIdDelete,
-    getUserRateLimitsApiV1AdminRateLimitsUserIdGet: mocks.getUserRateLimitsApiV1AdminRateLimitsUserIdGet,
-    updateUserRateLimitsApiV1AdminRateLimitsUserIdPut: mocks.updateUserRateLimitsApiV1AdminRateLimitsUserIdPut,
-    resetUserRateLimitsApiV1AdminRateLimitsUserIdResetPost:
-        mocks.resetUserRateLimitsApiV1AdminRateLimitsUserIdResetPost,
-    getDefaultRateLimitRulesApiV1AdminRateLimitsDefaultsGet:
-        mocks.getDefaultRateLimitRulesApiV1AdminRateLimitsDefaultsGet,
-}));
-
-vi.mock('$lib/api-interceptors');
-
-vi.mock('svelte-sonner', () => ({
-    toast: {
-        success: (...args: unknown[]) => mocks.addToast(...args),
-        error: (...args: unknown[]) => mocks.addToast(...args),
-        warning: (...args: unknown[]) => mocks.addToast(...args),
-        info: (...args: unknown[]) => mocks.addToast(...args),
-    },
-}));
+import { user, selectOption, createMockUser, createMockUsers, mockApi } from '$test/test-utils';
+import {
+    listUsersApiV1AdminUsersGet,
+    createUserApiV1AdminUsersPost,
+    updateUserApiV1AdminUsersUserIdPut,
+    deleteUserApiV1AdminUsersUserIdDelete,
+    getUserRateLimitsApiV1AdminRateLimitsUserIdGet,
+    updateUserRateLimitsApiV1AdminRateLimitsUserIdPut,
+    resetUserRateLimitsApiV1AdminRateLimitsUserIdResetPost,
+    getDefaultRateLimitRulesApiV1AdminRateLimitsDefaultsGet,
+} from '$lib/api';
+import { toast } from 'svelte-sonner';
 
 vi.mock('$lib/formatters', () => ({
     formatTimestamp: (ts: string) => (ts ? `formatted:${ts}` : 'N/A'),
 }));
 
 // Simple mock for AdminLayout that just renders children
-vi.mock('../AdminLayout.svelte', async () => {
+vi.mock('$routes/admin/AdminLayout.svelte', async () => {
     const { default: MockLayout } = await import('$routes/admin/__tests__/mocks/MockAdminLayout.svelte');
     return { default: MockLayout };
 });
@@ -51,33 +26,33 @@ vi.mock('../AdminLayout.svelte', async () => {
 import AdminUsers from '$routes/admin/AdminUsers.svelte';
 
 async function renderWithUsers(users = createMockUsers(3)) {
-    mocks.listUsersApiV1AdminUsersGet.mockResolvedValue({ data: { users, total: users.length }, error: null });
+    mockApi(listUsersApiV1AdminUsersGet).ok({ users, total: users.length, offset: 0, limit: 20 });
     const result = render(AdminUsers);
-    await waitFor(() => expect(mocks.listUsersApiV1AdminUsersGet).toHaveBeenCalled());
+    await waitFor(() => expect(vi.mocked(listUsersApiV1AdminUsersGet)).toHaveBeenCalled());
     return result;
 }
 
 describe('AdminUsers', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        mocks.listUsersApiV1AdminUsersGet.mockResolvedValue({ data: { users: [], total: 0 }, error: null });
-        mocks.getDefaultRateLimitRulesApiV1AdminRateLimitsDefaultsGet.mockResolvedValue({ data: [], error: null });
+        mockApi(listUsersApiV1AdminUsersGet).ok({ users: [], total: 0, offset: 0, limit: 20 });
+        mockApi(getDefaultRateLimitRulesApiV1AdminRateLimitsDefaultsGet).ok([]);
     });
 
     describe('initial loading', () => {
         it('calls loadUsers on mount', async () => {
             render(AdminUsers);
-            await waitFor(() => expect(mocks.listUsersApiV1AdminUsersGet).toHaveBeenCalledTimes(1));
+            await waitFor(() => expect(vi.mocked(listUsersApiV1AdminUsersGet)).toHaveBeenCalledTimes(1));
         });
 
         it('handles API error on load and shows toast', async () => {
             const error = { message: 'Network error' };
-            mocks.listUsersApiV1AdminUsersGet.mockImplementation(async () => {
-                mocks.addToast('Failed to load users');
-                return { data: null, error };
+            vi.mocked(listUsersApiV1AdminUsersGet).mockImplementation(async () => {
+                toast.error('Failed to load users');
+                return { data: null, error } as any;
             });
             render(AdminUsers);
-            await waitFor(() => expect(mocks.addToast).toHaveBeenCalledWith('Failed to load users'));
+            await waitFor(() => expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to load users'));
             expect(screen.queryByText('testuser')).not.toBeInTheDocument();
         });
     });
@@ -119,10 +94,10 @@ describe('AdminUsers', () => {
     describe('refresh functionality', () => {
         it('refresh button calls loadUsers', async () => {
             await renderWithUsers();
-            mocks.listUsersApiV1AdminUsersGet.mockClear();
+            vi.mocked(listUsersApiV1AdminUsersGet).mockClear();
             const refreshBtn = screen.getByRole('button', { name: /Refresh/i });
             await user.click(refreshBtn);
-            await waitFor(() => expect(mocks.listUsersApiV1AdminUsersGet).toHaveBeenCalled());
+            await waitFor(() => expect(vi.mocked(listUsersApiV1AdminUsersGet)).toHaveBeenCalled());
         });
     });
 
@@ -132,13 +107,13 @@ describe('AdminUsers', () => {
                 createMockUser({ username: 'alice', email: 'alice@test.com' }),
                 createMockUser({ user_id: 'u2', username: 'bob', email: 'bob@test.com' }),
             ];
-            mocks.listUsersApiV1AdminUsersGet.mockImplementation(async ({ query } = {}) => {
+            vi.mocked(listUsersApiV1AdminUsersGet).mockImplementation(async ({ query } = {}) => {
                 const search = (query as Record<string, unknown>)?.search as string | null;
                 const filtered = search ? allUsers.filter((u) => u.username.includes(search)) : allUsers;
-                return { data: { users: filtered, total: filtered.length }, error: null };
+                return { data: { users: filtered, total: filtered.length, offset: 0, limit: 20 }, error: null } as any;
             });
             render(AdminUsers);
-            await waitFor(() => expect(mocks.listUsersApiV1AdminUsersGet).toHaveBeenCalled());
+            await waitFor(() => expect(vi.mocked(listUsersApiV1AdminUsersGet)).toHaveBeenCalled());
 
             const searchInput = screen.getByPlaceholderText(/Search by username/i);
             await user.type(searchInput, 'alice');
@@ -153,13 +128,13 @@ describe('AdminUsers', () => {
                 createMockUser({ username: 'admin1', role: 'admin' }),
                 createMockUser({ user_id: 'u2', username: 'user1', role: 'user' }),
             ];
-            mocks.listUsersApiV1AdminUsersGet.mockImplementation(async ({ query } = {}) => {
+            vi.mocked(listUsersApiV1AdminUsersGet).mockImplementation(async ({ query } = {}) => {
                 const role = (query as Record<string, unknown>)?.role as string | null;
                 const filtered = role ? allUsers.filter((u) => u.role === role) : allUsers;
-                return { data: { users: filtered, total: filtered.length }, error: null };
+                return { data: { users: filtered, total: filtered.length, offset: 0, limit: 20 }, error: null } as any;
             });
             render(AdminUsers);
-            await waitFor(() => expect(mocks.listUsersApiV1AdminUsersGet).toHaveBeenCalled());
+            await waitFor(() => expect(vi.mocked(listUsersApiV1AdminUsersGet)).toHaveBeenCalled());
 
             const roleSelect = screen.getByRole('combobox', { name: /Role/i });
             selectOption(roleSelect, 'admin');
@@ -185,15 +160,15 @@ describe('AdminUsers', () => {
 
         it('resets filters on Reset button click', async () => {
             const users = createMockUsers(3);
-            mocks.listUsersApiV1AdminUsersGet.mockImplementation(async ({ query } = {}) => {
+            vi.mocked(listUsersApiV1AdminUsersGet).mockImplementation(async ({ query } = {}) => {
                 const search = (query as Record<string, unknown>)?.search as string | null;
                 if (search === 'nonexistent') {
-                    return { data: { users: [], total: 0 }, error: null };
+                    return { data: { users: [], total: 0, offset: 0, limit: 20 }, error: null } as any;
                 }
-                return { data: { users, total: users.length }, error: null };
+                return { data: { users, total: users.length, offset: 0, limit: 20 }, error: null } as any;
             });
             render(AdminUsers);
-            await waitFor(() => expect(mocks.listUsersApiV1AdminUsersGet).toHaveBeenCalled());
+            await waitFor(() => expect(vi.mocked(listUsersApiV1AdminUsersGet)).toHaveBeenCalled());
 
             const searchInput = screen.getByPlaceholderText(/Search by username/i);
             await user.type(searchInput, 'nonexistent');
@@ -240,7 +215,7 @@ describe('AdminUsers', () => {
         });
 
         it('submits new user data', async () => {
-            mocks.createUserApiV1AdminUsersPost.mockResolvedValue({ data: {}, error: null });
+            mockApi(createUserApiV1AdminUsersPost).ok({});
             await renderWithUsers();
             const [createButton] = screen.getAllByRole('button', { name: /Create User/i });
             await user.click(createButton!);
@@ -255,7 +230,7 @@ describe('AdminUsers', () => {
             await user.click(within(dialog).getByRole('button', { name: /Create User/i }));
 
             await waitFor(() => {
-                expect(mocks.createUserApiV1AdminUsersPost).toHaveBeenCalledWith({
+                expect(vi.mocked(createUserApiV1AdminUsersPost)).toHaveBeenCalledWith({
                     body: expect.objectContaining({
                         username: 'newuser',
                         email: 'new@test.com',
@@ -267,9 +242,9 @@ describe('AdminUsers', () => {
 
         it('handles validation error on create and shows toast', async () => {
             const error = { status: 422, detail: [{ loc: ['body', 'username'], msg: 'Required' }] };
-            mocks.createUserApiV1AdminUsersPost.mockImplementation(async () => {
-                mocks.addToast('Validation error: username: Required');
-                return { data: null, error };
+            vi.mocked(createUserApiV1AdminUsersPost).mockImplementation(async () => {
+                toast.error('Validation error: username: Required');
+                return { data: null, error } as any;
             });
             await renderWithUsers();
             const [createButton] = screen.getAllByRole('button', { name: /Create User/i });
@@ -282,7 +257,9 @@ describe('AdminUsers', () => {
             const dialog = screen.getByRole('dialog');
             await user.click(within(dialog).getByRole('button', { name: /Create User/i }));
 
-            await waitFor(() => expect(mocks.addToast).toHaveBeenCalledWith('Validation error: username: Required'));
+            await waitFor(() =>
+                expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Validation error: username: Required'),
+            );
         });
 
         it('closes modal on cancel', async () => {
@@ -315,7 +292,7 @@ describe('AdminUsers', () => {
         });
 
         it('submits updated user data', async () => {
-            mocks.updateUserApiV1AdminUsersUserIdPut.mockResolvedValue({ data: {}, error: null });
+            mockApi(updateUserApiV1AdminUsersUserIdPut).ok({});
             const users = [createMockUser({ user_id: 'u1', username: 'editme' })];
             await renderWithUsers(users);
 
@@ -329,7 +306,7 @@ describe('AdminUsers', () => {
             await user.click(screen.getByRole('button', { name: /Update User/i }));
 
             await waitFor(() => {
-                expect(mocks.updateUserApiV1AdminUsersUserIdPut).toHaveBeenCalledWith({
+                expect(vi.mocked(updateUserApiV1AdminUsersUserIdPut)).toHaveBeenCalledWith({
                     path: { user_id: 'u1' },
                     body: expect.objectContaining({ username: 'updated' }),
                 });
@@ -352,9 +329,12 @@ describe('AdminUsers', () => {
         });
 
         it('confirms deletion without cascade by default', async () => {
-            mocks.deleteUserApiV1AdminUsersUserIdDelete.mockResolvedValue({
-                data: { message: 'Deleted' },
-                error: null,
+            mockApi(deleteUserApiV1AdminUsersUserIdDelete).ok({
+                user_deleted: true,
+                executions: 0,
+                saved_scripts: 0,
+                notifications: 0,
+                user_settings: 0,
             });
             const users = [createMockUser({ user_id: 'del1', username: 'deleteme' })];
             await renderWithUsers(users);
@@ -367,7 +347,7 @@ describe('AdminUsers', () => {
             await user.click(within(dialog).getByRole('button', { name: /Delete User/i }));
 
             await waitFor(() => {
-                expect(mocks.deleteUserApiV1AdminUsersUserIdDelete).toHaveBeenCalledWith({
+                expect(vi.mocked(deleteUserApiV1AdminUsersUserIdDelete)).toHaveBeenCalledWith({
                     path: { user_id: 'del1' },
                     query: { cascade: false },
                 });
@@ -375,9 +355,12 @@ describe('AdminUsers', () => {
         });
 
         it('confirms deletion with cascade option', async () => {
-            mocks.deleteUserApiV1AdminUsersUserIdDelete.mockResolvedValue({
-                data: { message: 'Deleted' },
-                error: null,
+            mockApi(deleteUserApiV1AdminUsersUserIdDelete).ok({
+                user_deleted: true,
+                executions: 0,
+                saved_scripts: 0,
+                notifications: 0,
+                user_settings: 0,
             });
             const users = [createMockUser({ user_id: 'del1', username: 'deleteme' })];
             await renderWithUsers(users);
@@ -395,7 +378,7 @@ describe('AdminUsers', () => {
             await user.click(within(dialog).getByRole('button', { name: /Delete User/i }));
 
             await waitFor(() => {
-                expect(mocks.deleteUserApiV1AdminUsersUserIdDelete).toHaveBeenCalledWith({
+                expect(vi.mocked(deleteUserApiV1AdminUsersUserIdDelete)).toHaveBeenCalledWith({
                     path: { user_id: 'del1' },
                     query: { cascade: true },
                 });
@@ -404,9 +387,9 @@ describe('AdminUsers', () => {
 
         it('handles deletion error and shows toast', async () => {
             const error = { message: 'Cannot delete' };
-            mocks.deleteUserApiV1AdminUsersUserIdDelete.mockImplementation(async () => {
-                mocks.addToast('Failed to delete user');
-                return { data: null, error };
+            vi.mocked(deleteUserApiV1AdminUsersUserIdDelete).mockImplementation(async () => {
+                toast.error('Failed to delete user');
+                return { data: null, error } as any;
             });
             const users = [createMockUser({ username: 'deleteme' })];
             await renderWithUsers(users);
@@ -418,7 +401,7 @@ describe('AdminUsers', () => {
             const dialog = screen.getByRole('dialog');
             await user.click(within(dialog).getByRole('button', { name: /Delete User/i }));
 
-            await waitFor(() => expect(mocks.addToast).toHaveBeenCalledWith('Failed to delete user'));
+            await waitFor(() => expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to delete user'));
         });
 
         it('cancels deletion', async () => {
@@ -432,7 +415,7 @@ describe('AdminUsers', () => {
             await user.click(screen.getByRole('button', { name: /Cancel/i }));
 
             await waitFor(() => {
-                expect(mocks.deleteUserApiV1AdminUsersUserIdDelete).not.toHaveBeenCalled();
+                expect(vi.mocked(deleteUserApiV1AdminUsersUserIdDelete)).not.toHaveBeenCalled();
                 expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
             });
         });
@@ -468,9 +451,9 @@ describe('AdminUsers', () => {
         };
 
         it('opens rate limit modal for user', async () => {
-            mocks.getUserRateLimitsApiV1AdminRateLimitsUserIdGet.mockResolvedValue({
-                data: { rate_limit_config: mockRateLimitConfig, current_usage: {} },
-                error: null,
+            mockApi(getUserRateLimitsApiV1AdminRateLimitsUserIdGet).ok({
+                rate_limit_config: mockRateLimitConfig,
+                current_usage: {},
             });
             const users = [createMockUser({ username: 'ratelimited' })];
             await renderWithUsers(users);
@@ -481,14 +464,14 @@ describe('AdminUsers', () => {
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
-                expect(mocks.getUserRateLimitsApiV1AdminRateLimitsUserIdGet).toHaveBeenCalled();
+                expect(vi.mocked(getUserRateLimitsApiV1AdminRateLimitsUserIdGet)).toHaveBeenCalled();
             });
         });
 
         it('displays default rules in rate limit modal', async () => {
-            mocks.getUserRateLimitsApiV1AdminRateLimitsUserIdGet.mockResolvedValue({
-                data: { rate_limit_config: mockRateLimitConfig, current_usage: {} },
-                error: null,
+            mockApi(getUserRateLimitsApiV1AdminRateLimitsUserIdGet).ok({
+                rate_limit_config: mockRateLimitConfig,
+                current_usage: {},
             });
             const users = [createMockUser({ username: 'testuser' })];
             await renderWithUsers(users);
@@ -502,11 +485,11 @@ describe('AdminUsers', () => {
         });
 
         it('saves rate limit changes', async () => {
-            mocks.getUserRateLimitsApiV1AdminRateLimitsUserIdGet.mockResolvedValue({
-                data: { rate_limit_config: mockRateLimitConfig, current_usage: {} },
-                error: null,
+            mockApi(getUserRateLimitsApiV1AdminRateLimitsUserIdGet).ok({
+                rate_limit_config: mockRateLimitConfig,
+                current_usage: {},
             });
-            mocks.updateUserRateLimitsApiV1AdminRateLimitsUserIdPut.mockResolvedValue({ data: {}, error: null });
+            mockApi(updateUserRateLimitsApiV1AdminRateLimitsUserIdPut).ok({});
             const users = [createMockUser({ user_id: 'u1', username: 'testuser' })];
             await renderWithUsers(users);
 
@@ -517,7 +500,7 @@ describe('AdminUsers', () => {
             await user.click(screen.getByRole('button', { name: /Save Changes/i }));
 
             await waitFor(() => {
-                expect(mocks.updateUserRateLimitsApiV1AdminRateLimitsUserIdPut).toHaveBeenCalledWith({
+                expect(vi.mocked(updateUserRateLimitsApiV1AdminRateLimitsUserIdPut)).toHaveBeenCalledWith({
                     path: { user_id: 'u1' },
                     body: expect.any(Object),
                 });
@@ -526,13 +509,13 @@ describe('AdminUsers', () => {
 
         it('handles rate limit save error and shows toast', async () => {
             const error = { status: 422, detail: 'Invalid config' };
-            mocks.getUserRateLimitsApiV1AdminRateLimitsUserIdGet.mockResolvedValue({
-                data: { rate_limit_config: mockRateLimitConfig, current_usage: {} },
-                error: null,
+            mockApi(getUserRateLimitsApiV1AdminRateLimitsUserIdGet).ok({
+                rate_limit_config: mockRateLimitConfig,
+                current_usage: {},
             });
-            mocks.updateUserRateLimitsApiV1AdminRateLimitsUserIdPut.mockImplementation(async () => {
-                mocks.addToast('Failed to save rate limits');
-                return { data: null, error };
+            vi.mocked(updateUserRateLimitsApiV1AdminRateLimitsUserIdPut).mockImplementation(async () => {
+                toast.error('Failed to save rate limits');
+                return { data: null, error } as any;
             });
             const users = [createMockUser({ username: 'testuser' })];
             await renderWithUsers(users);
@@ -543,13 +526,13 @@ describe('AdminUsers', () => {
 
             await user.click(screen.getByRole('button', { name: /Save Changes/i }));
 
-            await waitFor(() => expect(mocks.addToast).toHaveBeenCalledWith('Failed to save rate limits'));
+            await waitFor(() => expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to save rate limits'));
         });
 
         it('adds new rate limit rule', async () => {
-            mocks.getUserRateLimitsApiV1AdminRateLimitsUserIdGet.mockResolvedValue({
-                data: { rate_limit_config: mockRateLimitConfig, current_usage: {} },
-                error: null,
+            mockApi(getUserRateLimitsApiV1AdminRateLimitsUserIdGet).ok({
+                rate_limit_config: mockRateLimitConfig,
+                current_usage: {},
             });
             const users = [createMockUser({ username: 'testuser' })];
             await renderWithUsers(users);
@@ -566,11 +549,11 @@ describe('AdminUsers', () => {
         });
 
         it('resets rate limit counters', async () => {
-            mocks.getUserRateLimitsApiV1AdminRateLimitsUserIdGet.mockResolvedValue({
-                data: { rate_limit_config: mockRateLimitConfig, current_usage: { '/api/test': { count: 5 } } },
-                error: null,
+            mockApi(getUserRateLimitsApiV1AdminRateLimitsUserIdGet).ok({
+                rate_limit_config: mockRateLimitConfig,
+                current_usage: { '/api/test': { count: 5 } },
             });
-            mocks.resetUserRateLimitsApiV1AdminRateLimitsUserIdResetPost.mockResolvedValue({ data: {}, error: null });
+            mockApi(resetUserRateLimitsApiV1AdminRateLimitsUserIdResetPost).ok({});
             const users = [createMockUser({ user_id: 'u1', username: 'testuser' })];
             await renderWithUsers(users);
 
@@ -581,7 +564,7 @@ describe('AdminUsers', () => {
             await user.click(screen.getByRole('button', { name: /Reset All Counters/i }));
 
             await waitFor(() => {
-                expect(mocks.resetUserRateLimitsApiV1AdminRateLimitsUserIdResetPost).toHaveBeenCalledWith({
+                expect(vi.mocked(resetUserRateLimitsApiV1AdminRateLimitsUserIdResetPost)).toHaveBeenCalledWith({
                     path: { user_id: 'u1' },
                 });
             });
@@ -626,7 +609,7 @@ describe('AdminUsers', () => {
 
     describe('user form validation', () => {
         it('requires username for new user', async () => {
-            mocks.createUserApiV1AdminUsersPost.mockResolvedValue({ data: {}, error: null });
+            mockApi(createUserApiV1AdminUsersPost).ok({});
             await renderWithUsers();
 
             const [createButton] = screen.getAllByRole('button', { name: /Create User/i });
@@ -639,11 +622,11 @@ describe('AdminUsers', () => {
             await user.click(within(dialog).getByRole('button', { name: /Create User/i }));
 
             // Native HTML required attribute prevents form submission
-            expect(mocks.createUserApiV1AdminUsersPost).not.toHaveBeenCalled();
+            expect(vi.mocked(createUserApiV1AdminUsersPost)).not.toHaveBeenCalled();
         });
 
         it('requires password for new user', async () => {
-            mocks.createUserApiV1AdminUsersPost.mockResolvedValue({ data: {}, error: null });
+            mockApi(createUserApiV1AdminUsersPost).ok({});
             await renderWithUsers();
 
             const [createButton] = screen.getAllByRole('button', { name: /Create User/i });
@@ -656,11 +639,11 @@ describe('AdminUsers', () => {
             await user.click(within(dialog).getByRole('button', { name: /Create User/i }));
 
             // Native HTML required attribute prevents form submission
-            expect(mocks.createUserApiV1AdminUsersPost).not.toHaveBeenCalled();
+            expect(vi.mocked(createUserApiV1AdminUsersPost)).not.toHaveBeenCalled();
         });
 
         it('password is optional for edit', async () => {
-            mocks.updateUserApiV1AdminUsersUserIdPut.mockResolvedValue({ data: {}, error: null });
+            mockApi(updateUserApiV1AdminUsersUserIdPut).ok({});
             const users = [createMockUser({ user_id: 'u1', username: 'editme' })];
             await renderWithUsers(users);
 
@@ -672,7 +655,7 @@ describe('AdminUsers', () => {
             await user.click(screen.getByRole('button', { name: /Update User/i }));
 
             await waitFor(() => {
-                expect(mocks.updateUserApiV1AdminUsersUserIdPut).toHaveBeenCalledWith({
+                expect(vi.mocked(updateUserApiV1AdminUsersUserIdPut)).toHaveBeenCalledWith({
                     path: { user_id: 'u1' },
                     body: expect.not.objectContaining({ password: expect.anything() }),
                 });
@@ -683,9 +666,9 @@ describe('AdminUsers', () => {
     describe('error handling', () => {
         it('handles API error when loading rate limits and shows toast', async () => {
             const error = { message: 'Failed to load' };
-            mocks.getUserRateLimitsApiV1AdminRateLimitsUserIdGet.mockImplementation(async () => {
-                mocks.addToast('Failed to load rate limits');
-                return { data: null, error };
+            vi.mocked(getUserRateLimitsApiV1AdminRateLimitsUserIdGet).mockImplementation(async () => {
+                toast.error('Failed to load rate limits');
+                return { data: null, error } as any;
             });
             const users = [createMockUser({ username: 'testuser' })];
             await renderWithUsers(users);
@@ -693,27 +676,24 @@ describe('AdminUsers', () => {
             const [rateLimitButton] = screen.getAllByTitle('Manage Rate Limits');
             await user.click(rateLimitButton!);
 
-            await waitFor(() => expect(mocks.addToast).toHaveBeenCalledWith('Failed to load rate limits'));
+            await waitFor(() => expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to load rate limits'));
         });
 
         it('handles API error when resetting rate limits and shows toast', async () => {
             const resetError = { message: 'Reset failed' };
-            mocks.getUserRateLimitsApiV1AdminRateLimitsUserIdGet.mockResolvedValue({
-                data: {
-                    rate_limit_config: {
-                        user_id: 'u1',
-                        rules: [],
-                        global_multiplier: 1.0,
-                        bypass_rate_limit: false,
-                        notes: '',
-                    },
-                    current_usage: { '/api': { count: 1 } },
+            mockApi(getUserRateLimitsApiV1AdminRateLimitsUserIdGet).ok({
+                rate_limit_config: {
+                    user_id: 'u1',
+                    rules: [],
+                    global_multiplier: 1.0,
+                    bypass_rate_limit: false,
+                    notes: '',
                 },
-                error: null,
+                current_usage: { '/api': { count: 1 } },
             });
-            mocks.resetUserRateLimitsApiV1AdminRateLimitsUserIdResetPost.mockImplementation(async () => {
-                mocks.addToast('Failed to reset rate limits');
-                return { data: null, error: resetError };
+            vi.mocked(resetUserRateLimitsApiV1AdminRateLimitsUserIdResetPost).mockImplementation(async () => {
+                toast.error('Failed to reset rate limits');
+                return { data: null, error: resetError } as any;
             });
             const users = [createMockUser({ user_id: 'u1', username: 'testuser' })];
             await renderWithUsers(users);
@@ -726,7 +706,7 @@ describe('AdminUsers', () => {
 
             await user.click(screen.getByRole('button', { name: /Reset All Counters/i }));
 
-            await waitFor(() => expect(mocks.addToast).toHaveBeenCalledWith('Failed to reset rate limits'));
+            await waitFor(() => expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to reset rate limits'));
         });
     });
 });

--- a/frontend/src/routes/admin/__tests__/AdminUsers.test.ts
+++ b/frontend/src/routes/admin/__tests__/AdminUsers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/svelte';
-import { user, createMockUser, createMockUsers } from '$test/test-utils';
+import { user, selectOption, createMockUser, createMockUsers } from '$test/test-utils';
 
 const mocks = vi.hoisted(() => ({
     listUsersApiV1AdminUsersGet: vi.fn(),
@@ -162,7 +162,7 @@ describe('AdminUsers', () => {
             await waitFor(() => expect(mocks.listUsersApiV1AdminUsersGet).toHaveBeenCalled());
 
             const roleSelect = screen.getByRole('combobox', { name: /Role/i });
-            await user.selectOptions(roleSelect, 'admin');
+            selectOption(roleSelect, 'admin');
             await waitFor(() => {
                 expect(screen.getAllByText('admin1')).toHaveLength(2);
                 expect(screen.queryAllByText('user1')).toHaveLength(0);
@@ -176,7 +176,7 @@ describe('AdminUsers', () => {
             ];
             await renderWithUsers(users);
             const statusSelect = screen.getByRole('combobox', { name: /Status/i });
-            await user.selectOptions(statusSelect, 'disabled');
+            selectOption(statusSelect, 'disabled');
             await waitFor(() => {
                 expect(screen.getAllByText('disableduser')).toHaveLength(2);
                 expect(screen.queryAllByText('activeuser')).toHaveLength(0);
@@ -220,7 +220,7 @@ describe('AdminUsers', () => {
             await renderWithUsers(users);
             await user.click(screen.getByRole('button', { name: /Advanced/i }));
             const bypassSelect = screen.getByRole('combobox', { name: /Bypass Rate Limit/i });
-            await user.selectOptions(bypassSelect, 'yes');
+            selectOption(bypassSelect, 'yes');
             await waitFor(() => {
                 expect(screen.getAllByText('bypassed')).toHaveLength(2);
                 expect(screen.queryAllByText('limited')).toHaveLength(0);
@@ -603,7 +603,7 @@ describe('AdminUsers', () => {
             await renderWithUsers(users);
 
             const statusSelect = screen.getByRole('combobox', { name: /Status/i });
-            await user.selectOptions(statusSelect, 'active');
+            selectOption(statusSelect, 'active');
 
             await waitFor(() => {
                 expect(screen.getByText(/Users \(1 of 2\)/)).toBeInTheDocument();

--- a/frontend/src/stores/__tests__/auth.test.ts
+++ b/frontend/src/stores/__tests__/auth.test.ts
@@ -40,7 +40,6 @@ describe('auth store', () => {
     let sessionStorageData: Record<string, string> = {};
 
     beforeEach(async () => {
-        // Reset sessionStorage mock
         sessionStorageData = {};
         vi.mocked(sessionStorage.getItem).mockImplementation((key: string) => sessionStorageData[key] ?? null);
         vi.mocked(sessionStorage.setItem).mockImplementation((key: string, value: string) => {
@@ -50,14 +49,12 @@ describe('auth store', () => {
             delete sessionStorageData[key];
         });
 
-        // Reset all mocks
         mockLoginApi.mockReset();
         mockLogoutApi.mockReset();
         mockGetProfileApi.mockReset();
         mockClearUserSettings.mockReset();
         mockLoadUserSettings.mockReset().mockResolvedValue({});
 
-        // Clear module cache to reset store state
         vi.resetModules();
     });
 
@@ -211,7 +208,6 @@ describe('auth store', () => {
 
     describe('logout', () => {
         it('clears auth state on logout', async () => {
-            // Set up authenticated state
             mockLoginApi.mockResolvedValue({
                 data: { username: 'testuser', role: 'user', csrf_token: 'token' },
                 error: null,
@@ -290,11 +286,9 @@ describe('auth store', () => {
 
             const { authStore } = await import('$stores/auth.svelte');
 
-            // First call - should hit API
             await authStore.verifyAuth(true);
             expect(mockGetProfileApi).toHaveBeenCalledTimes(1);
 
-            // Second call without force - should use cache
             await authStore.verifyAuth(false);
             expect(mockGetProfileApi).toHaveBeenCalledTimes(1);
         });
@@ -313,7 +307,6 @@ describe('auth store', () => {
         it('returns cached value on network error (offline-first)', async () => {
             const restoreConsole = suppressConsoleWarn();
 
-            // First successful verification
             mockGetProfileApi.mockResolvedValueOnce({ data: PROFILE_RESPONSE, error: null });
 
             const { authStore } = await import('$stores/auth.svelte');
@@ -321,7 +314,6 @@ describe('auth store', () => {
             const firstResult = await authStore.verifyAuth(true);
             expect(firstResult).toBe(true);
 
-            // Second call with network error
             mockGetProfileApi.mockRejectedValueOnce(new Error('Network error'));
 
             const secondResult = await authStore.verifyAuth(true);

--- a/frontend/src/stores/__tests__/auth.test.ts
+++ b/frontend/src/stores/__tests__/auth.test.ts
@@ -5,7 +5,7 @@ const mockLoginApi = vi.fn();
 const mockLogoutApi = vi.fn();
 const mockGetProfileApi = vi.fn();
 
-vi.mock('../../lib/api', () => ({
+vi.mock('$lib/api', () => ({
     loginApiV1AuthLoginPost: (...args: unknown[]) => mockLoginApi(...args),
     logoutApiV1AuthLogoutPost: (...args: unknown[]) => mockLogoutApi(...args),
     getCurrentUserProfileApiV1AuthMeGet: (...args: unknown[]) => mockGetProfileApi(...args),
@@ -13,7 +13,7 @@ vi.mock('../../lib/api', () => ({
 
 // Mock clearUserSettings (static import in auth.svelte.ts)
 const mockClearUserSettings = vi.fn();
-vi.mock('../userSettings.svelte', () => ({
+vi.mock('$stores/userSettings.svelte', () => ({
     clearUserSettings: () => mockClearUserSettings(),
     setUserSettings: vi.fn(),
     userSettingsStore: { settings: null, editorSettings: {} },
@@ -21,7 +21,7 @@ vi.mock('../userSettings.svelte', () => ({
 
 // Mock loadUserSettings (dynamic import in auth.svelte.ts)
 const mockLoadUserSettings = vi.fn();
-vi.mock('../../lib/user-settings', () => ({
+vi.mock('$lib/user-settings', () => ({
     loadUserSettings: () => mockLoadUserSettings(),
 }));
 

--- a/frontend/src/stores/__tests__/theme.test.ts
+++ b/frontend/src/stores/__tests__/theme.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 // Mock the dynamic imports before importing the theme module
-vi.mock('../../lib/user-settings', () => ({
+vi.mock('$lib/user-settings', () => ({
     saveUserSettings: vi.fn().mockResolvedValue(true),
 }));
 
-vi.mock('../auth.svelte', () => ({
+vi.mock('$stores/auth.svelte', () => ({
     authStore: {
         isAuthenticated: false,
     },

--- a/frontend/src/stores/__tests__/theme.test.ts
+++ b/frontend/src/stores/__tests__/theme.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
-// Mock the dynamic imports before importing the theme module
 vi.mock('$lib/user-settings', () => ({
     saveUserSettings: vi.fn().mockResolvedValue(true),
 }));
@@ -23,7 +22,6 @@ describe('theme store', () => {
 
         document.documentElement.classList.remove('dark');
 
-        // Clear module cache to reset store state
         vi.resetModules();
     });
 
@@ -102,7 +100,6 @@ describe('theme store', () => {
 
         it('cycles from auto to light', async () => {
             const { themeStore } = await import('$stores/theme.svelte');
-            // Default is auto
             themeStore.toggleTheme();
             expect(themeStore.value).toBe('light');
         });

--- a/frontend/src/utils/__tests__/meta.test.ts
+++ b/frontend/src/utils/__tests__/meta.test.ts
@@ -6,14 +6,10 @@ describe('meta utilities', () => {
     let metaDescription: HTMLMetaElement | null;
 
     beforeEach(() => {
-        // Save original state
         originalTitle = document.title;
         metaDescription = document.querySelector('meta[name="description"]');
-
-        // Reset document state
         document.title = 'Original Title';
 
-        // Remove existing meta description if any
         const existingMeta = document.querySelector('meta[name="description"]');
         if (existingMeta) {
             existingMeta.remove();
@@ -21,16 +17,13 @@ describe('meta utilities', () => {
     });
 
     afterEach(() => {
-        // Restore original state
         document.title = originalTitle;
 
-        // Clean up any meta tags we created
         const testMeta = document.querySelector('meta[name="description"]');
         if (testMeta) {
             testMeta.remove();
         }
 
-        // Restore original meta if it existed
         if (metaDescription) {
             document.head.appendChild(metaDescription);
         }
@@ -62,7 +55,6 @@ describe('meta utilities', () => {
         });
 
         it('updates existing meta description', () => {
-            // Create existing meta
             const existingMeta = document.createElement('meta');
             existingMeta.setAttribute('name', 'description');
             existingMeta.setAttribute('content', 'Old description');

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { svelteTesting } from '@testing-library/svelte/vite';
-import pkg from './package.json' with { type: 'json' };
 
 // --8<-- [start:config]
 export default defineConfig({
@@ -11,25 +10,24 @@ export default defineConfig({
   ],
   test: {
     pool: 'threads',
-    maxWorkers: 8,
-    minWorkers: 2,
+    maxWorkers: process.env.CI ? 4 : 8,
+    minWorkers: process.env.CI ? 4 : 2,
     isolate: false,
     css: false,
     testTimeout: 10_000,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.{test,spec}.{js,ts}'],
-    fakeTimers: { shouldAdvanceTime: true },
     deps: {
       optimizer: {
         web: {
-          include: Object.keys(pkg.dependencies),
+          include: ['svelte', '@lucide/svelte', 'date-fns', 'dompurify', 'ansi_up', 'svelte-sonner'],
         },
       },
     },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html', 'lcov'],
+      reporter: process.env.CI ? ['text', 'lcov'] : ['text', 'html', 'lcov'],
       include: ['src/**/*.{ts,svelte}'],
       exclude: [
         'src/lib/api/**',

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     pool: 'threads',
     maxWorkers: process.env.CI ? 4 : 8,
     minWorkers: process.env.CI ? 4 : 2,
-    isolate: false,
+    isolate: true,
     css: false,
     testTimeout: 10_000,
     environment: 'happy-dom',

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -4,7 +4,6 @@ import { cleanup } from '@testing-library/svelte';
 
 vi.useFakeTimers({ shouldAdvanceTime: true });
 
-// Auto-mock all $lib/api exports as vi.fn()
 vi.mock('$lib/api');
 
 // svelte-sonner needs a factory (toast is an object with methods, not a function)
@@ -12,10 +11,8 @@ vi.mock('svelte-sonner', () => ({
     toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
 }));
 
-// Router: stub route() decorator and provide goto as vi.fn()
 vi.mock('@mateothegreat/svelte5-router', () => ({ route: () => {}, goto: vi.fn() }));
 
-// api-interceptors: real unwrap/unwrapOr logic, simple getErrorMessage stub
 vi.mock('$lib/api-interceptors', () => ({
     unwrap: vi.fn((result: { data?: unknown; error?: unknown }) => {
         if (result.error) throw result.error;
@@ -34,7 +31,6 @@ vi.mock('$lib/api-interceptors', () => ({
 // API errors are handled by interceptor - just silence the rejection in tests
 process.on('unhandledRejection', () => {});
 
-// Mock localStorage
 const localStorageStore: Record<string, string> = {};
 const localStorageMock = {
     getItem: vi.fn((key: string) => localStorageStore[key] ?? null),
@@ -54,7 +50,6 @@ const localStorageMock = {
 };
 vi.stubGlobal('localStorage', localStorageMock);
 
-// Mock sessionStorage
 const sessionStorageStore: Record<string, string> = {};
 const sessionStorageMock = {
     getItem: vi.fn((key: string) => sessionStorageStore[key] ?? null),
@@ -74,7 +69,6 @@ const sessionStorageMock = {
 };
 vi.stubGlobal('sessionStorage', sessionStorageMock);
 
-// Mock matchMedia for theme tests (defaults to light mode)
 vi.stubGlobal(
     'matchMedia',
     vi.fn().mockImplementation((query: string) => ({
@@ -89,7 +83,6 @@ vi.stubGlobal(
     })),
 );
 
-// Mock ResizeObserver
 vi.stubGlobal(
     'ResizeObserver',
     vi.fn().mockImplementation(() => ({
@@ -99,7 +92,6 @@ vi.stubGlobal(
     })),
 );
 
-// Mock IntersectionObserver
 vi.stubGlobal(
     'IntersectionObserver',
     vi.fn().mockImplementation(() => ({
@@ -133,7 +125,6 @@ vi.stubGlobal(
     } as typeof origQSA;
 }
 
-// Mock Element.prototype.animate for Svelte transitions (canonical global stub)
 Element.prototype.animate = vi.fn().mockImplementation(() => {
     const mock = {
         _onfinish: null as (() => void) | null,

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { vi, beforeEach } from 'vitest';
 import { cleanup } from '@testing-library/svelte';
 
-vi.useFakeTimers();
+vi.useFakeTimers({ shouldAdvanceTime: true });
 
 // Global handler for promise rejections (mirrors main.ts behavior)
 // API errors are handled by interceptor - just silence the rejection in tests
@@ -73,6 +73,30 @@ vi.stubGlobal('IntersectionObserver', vi.fn().mockImplementation(() => ({
   unobserve: vi.fn(),
   disconnect: vi.fn(),
 })));
+
+// Polyfill :checked for <option> elements (happy-dom doesn't support it).
+// Svelte's bind_select_value reads select.querySelector(':checked') on change events,
+// so without this polyfill bind:value never updates in tests.
+{
+  const origQS = HTMLSelectElement.prototype.querySelector;
+  HTMLSelectElement.prototype.querySelector = function (selector: string) {
+    if (selector === ':checked') {
+      for (const opt of this.options) {
+        if (opt.selected) return opt;
+      }
+      return null;
+    }
+    return origQS.call(this, selector);
+  } as typeof origQS;
+
+  const origQSA = HTMLSelectElement.prototype.querySelectorAll;
+  HTMLSelectElement.prototype.querySelectorAll = function (selector: string) {
+    if (selector === ':checked') {
+      return Array.from(this.options).filter(o => o.selected) as unknown as ReturnType<typeof origQSA>;
+    }
+    return origQSA.call(this, selector);
+  } as typeof origQSA;
+}
 
 // Mock Element.prototype.animate for Svelte transitions (canonical global stub)
 Element.prototype.animate = vi.fn().mockImplementation(() => {

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -167,7 +167,7 @@ Element.prototype.animate = vi.fn().mockImplementation(() => {
     return mock as unknown as Animation;
 });
 
-// Reset storage and DOM between every test (required for isolate: false)
+// Reset storage and DOM between every test
 beforeEach(() => {
     Object.keys(localStorageStore).forEach((key) => delete localStorageStore[key]);
     Object.keys(sessionStorageStore).forEach((key) => delete sessionStorageStore[key]);

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -4,6 +4,32 @@ import { cleanup } from '@testing-library/svelte';
 
 vi.useFakeTimers({ shouldAdvanceTime: true });
 
+// Auto-mock all $lib/api exports as vi.fn()
+vi.mock('$lib/api');
+
+// svelte-sonner needs a factory (toast is an object with methods, not a function)
+vi.mock('svelte-sonner', () => ({
+    toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}));
+
+// Router: stub route() decorator and provide goto as vi.fn()
+vi.mock('@mateothegreat/svelte5-router', () => ({ route: () => {}, goto: vi.fn() }));
+
+// api-interceptors: real unwrap/unwrapOr logic, simple getErrorMessage stub
+vi.mock('$lib/api-interceptors', () => ({
+    unwrap: vi.fn((result: { data?: unknown; error?: unknown }) => {
+        if (result.error) throw result.error;
+        if (result.data === undefined) throw new Error('Unexpected empty response');
+        return result.data;
+    }),
+    unwrapOr: vi.fn((result: { data?: unknown; error?: unknown }, fallback: unknown) => {
+        if (result.error || result.data === undefined) return fallback;
+        return result.data;
+    }),
+    getErrorMessage: vi.fn((_err: unknown, fallback: string = 'An error occurred') => fallback),
+    initializeApiInterceptors: vi.fn(),
+}));
+
 // Global handler for promise rejections (mirrors main.ts behavior)
 // API errors are handled by interceptor - just silence the rejection in tests
 process.on('unhandledRejection', () => {});
@@ -11,120 +37,148 @@ process.on('unhandledRejection', () => {});
 // Mock localStorage
 const localStorageStore: Record<string, string> = {};
 const localStorageMock = {
-  getItem: vi.fn((key: string) => localStorageStore[key] ?? null),
-  setItem: vi.fn((key: string, value: string) => {
-    localStorageStore[key] = value;
-  }),
-  removeItem: vi.fn((key: string) => {
-    delete localStorageStore[key];
-  }),
-  clear: vi.fn(() => {
-    Object.keys(localStorageStore).forEach(key => delete localStorageStore[key]);
-  }),
-  get length() {
-    return Object.keys(localStorageStore).length;
-  },
-  key: vi.fn((index: number) => Object.keys(localStorageStore)[index] ?? null),
+    getItem: vi.fn((key: string) => localStorageStore[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+        localStorageStore[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+        delete localStorageStore[key];
+    }),
+    clear: vi.fn(() => {
+        Object.keys(localStorageStore).forEach((key) => delete localStorageStore[key]);
+    }),
+    get length() {
+        return Object.keys(localStorageStore).length;
+    },
+    key: vi.fn((index: number) => Object.keys(localStorageStore)[index] ?? null),
 };
 vi.stubGlobal('localStorage', localStorageMock);
 
 // Mock sessionStorage
 const sessionStorageStore: Record<string, string> = {};
 const sessionStorageMock = {
-  getItem: vi.fn((key: string) => sessionStorageStore[key] ?? null),
-  setItem: vi.fn((key: string, value: string) => {
-    sessionStorageStore[key] = value;
-  }),
-  removeItem: vi.fn((key: string) => {
-    delete sessionStorageStore[key];
-  }),
-  clear: vi.fn(() => {
-    Object.keys(sessionStorageStore).forEach(key => delete sessionStorageStore[key]);
-  }),
-  get length() {
-    return Object.keys(sessionStorageStore).length;
-  },
-  key: vi.fn((index: number) => Object.keys(sessionStorageStore)[index] ?? null),
+    getItem: vi.fn((key: string) => sessionStorageStore[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+        sessionStorageStore[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+        delete sessionStorageStore[key];
+    }),
+    clear: vi.fn(() => {
+        Object.keys(sessionStorageStore).forEach((key) => delete sessionStorageStore[key]);
+    }),
+    get length() {
+        return Object.keys(sessionStorageStore).length;
+    },
+    key: vi.fn((index: number) => Object.keys(sessionStorageStore)[index] ?? null),
 };
 vi.stubGlobal('sessionStorage', sessionStorageMock);
 
 // Mock matchMedia for theme tests (defaults to light mode)
-vi.stubGlobal('matchMedia', vi.fn().mockImplementation((query: string) => ({
-  matches: false,
-  media: query,
-  onchange: null,
-  addListener: vi.fn(),
-  removeListener: vi.fn(),
-  addEventListener: vi.fn(),
-  removeEventListener: vi.fn(),
-  dispatchEvent: vi.fn(),
-})));
+vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    })),
+);
 
 // Mock ResizeObserver
-vi.stubGlobal('ResizeObserver', vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-})));
+vi.stubGlobal(
+    'ResizeObserver',
+    vi.fn().mockImplementation(() => ({
+        observe: vi.fn(),
+        unobserve: vi.fn(),
+        disconnect: vi.fn(),
+    })),
+);
 
 // Mock IntersectionObserver
-vi.stubGlobal('IntersectionObserver', vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-})));
+vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn().mockImplementation(() => ({
+        observe: vi.fn(),
+        unobserve: vi.fn(),
+        disconnect: vi.fn(),
+    })),
+);
 
 // Polyfill :checked for <option> elements (happy-dom doesn't support it).
 // Svelte's bind_select_value reads select.querySelector(':checked') on change events,
 // so without this polyfill bind:value never updates in tests.
 {
-  const origQS = HTMLSelectElement.prototype.querySelector;
-  HTMLSelectElement.prototype.querySelector = function (selector: string) {
-    if (selector === ':checked') {
-      for (const opt of this.options) {
-        if (opt.selected) return opt;
-      }
-      return null;
-    }
-    return origQS.call(this, selector);
-  } as typeof origQS;
+    const origQS = HTMLSelectElement.prototype.querySelector;
+    HTMLSelectElement.prototype.querySelector = function (selector: string) {
+        if (selector === ':checked') {
+            for (const opt of this.options) {
+                if (opt.selected) return opt;
+            }
+            return null;
+        }
+        return origQS.call(this, selector);
+    } as typeof origQS;
 
-  const origQSA = HTMLSelectElement.prototype.querySelectorAll;
-  HTMLSelectElement.prototype.querySelectorAll = function (selector: string) {
-    if (selector === ':checked') {
-      return Array.from(this.options).filter(o => o.selected) as unknown as ReturnType<typeof origQSA>;
-    }
-    return origQSA.call(this, selector);
-  } as typeof origQSA;
+    const origQSA = HTMLSelectElement.prototype.querySelectorAll;
+    HTMLSelectElement.prototype.querySelectorAll = function (selector: string) {
+        if (selector === ':checked') {
+            return Array.from(this.options).filter((o) => o.selected) as unknown as ReturnType<typeof origQSA>;
+        }
+        return origQSA.call(this, selector);
+    } as typeof origQSA;
 }
 
 // Mock Element.prototype.animate for Svelte transitions (canonical global stub)
 Element.prototype.animate = vi.fn().mockImplementation(() => {
-  const mock = {
-    _onfinish: null as (() => void) | null,
-    get onfinish() { return this._onfinish; },
-    set onfinish(fn: (() => void) | null) {
-      this._onfinish = fn;
-      if (fn) queueMicrotask(fn);
-    },
-    cancel: vi.fn(), finish: vi.fn(), pause: vi.fn(), play: vi.fn(), reverse: vi.fn(),
-    commitStyles: vi.fn(), persist: vi.fn(),
-    currentTime: 0, playbackRate: 1, pending: false,
-    playState: 'running' as AnimationPlayState,
-    replaceState: 'active' as AnimationReplaceState,
-    startTime: 0, timeline: null, id: '', effect: null,
-    addEventListener: vi.fn(), removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(() => true), updatePlaybackRate: vi.fn(),
-    get finished() { return Promise.resolve(this as unknown as Animation); },
-    get ready() { return Promise.resolve(this as unknown as Animation); },
-    oncancel: null, onremove: null,
-  };
-  return mock as unknown as Animation;
+    const mock = {
+        _onfinish: null as (() => void) | null,
+        get onfinish() {
+            return this._onfinish;
+        },
+        set onfinish(fn: (() => void) | null) {
+            this._onfinish = fn;
+            if (fn) queueMicrotask(fn);
+        },
+        cancel: vi.fn(),
+        finish: vi.fn(),
+        pause: vi.fn(),
+        play: vi.fn(),
+        reverse: vi.fn(),
+        commitStyles: vi.fn(),
+        persist: vi.fn(),
+        currentTime: 0,
+        playbackRate: 1,
+        pending: false,
+        playState: 'running' as AnimationPlayState,
+        replaceState: 'active' as AnimationReplaceState,
+        startTime: 0,
+        timeline: null,
+        id: '',
+        effect: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(() => true),
+        updatePlaybackRate: vi.fn(),
+        get finished() {
+            return Promise.resolve(this as unknown as Animation);
+        },
+        get ready() {
+            return Promise.resolve(this as unknown as Animation);
+        },
+        oncancel: null,
+        onremove: null,
+    };
+    return mock as unknown as Animation;
 });
 
 // Reset storage and DOM between every test (required for isolate: false)
 beforeEach(() => {
-  Object.keys(localStorageStore).forEach(key => delete localStorageStore[key]);
-  Object.keys(sessionStorageStore).forEach(key => delete sessionStorageStore[key]);
-  cleanup();
+    Object.keys(localStorageStore).forEach((key) => delete localStorageStore[key]);
+    Object.keys(sessionStorageStore).forEach((key) => delete sessionStorageStore[key]);
+    cleanup();
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up CI test runs by parallelizing E2E setup and cutting Python env syncs. Frontend tests now run on happy-dom with isolation, centralized mocks, and cleaner select/checkbox binding.

- **Refactors**
  - e2e-boot pre-pulls executor images and Kueue manifest in background; e2e-ready verifies manifest SHA256 with timeout, waits on background PIDs, can skip Kueue install, waits for image pulls, and health checks poll every 1s.
  - Workflows use uv run --no-sync for pytest, ruff, and mypy; mypy sync includes the test group for test-only deps.
  - Vitest uses happy-dom, re-enables test isolation, tunes worker counts for CI, trims optimizer deps, and drops jsdom.
  - Centralized frontend test mocks in setup; added mockApi and selectOption helpers; tests use path aliases. Pagination and AutoRefreshControl bind values; onPageSizeChange has no argument and admin pages reset to page 1. Removed redundant test comments.

<sup>Written for commit 6775931ac8673d31369a6d2aafc05f71546b3747. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Faster, more reliable CI/E2E: background pre-pulls for images/manifests, optional Kueue install flag, tightened readiness checks, reduced health-check intervals, and workflow command invocation tweaks.

* **New Features**
  * Pagination now supports two-way page-size binding; page-size change callback is parameterless and handlers reset to page 1.

* **Tests**
  * Test suite migrated to happy-dom; unified mocking utilities (central mockApi and selectOption), broader global test setup and storage/observer polyfills, and removed many local toast spies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->